### PR TITLE
add hrPerSprint and voyageRole back into teams endpoints

### DIFF
--- a/src/global/selects/teams.select.ts
+++ b/src/global/selects/teams.select.ts
@@ -25,6 +25,12 @@ export const publicVoyageTeamUserSelect = {
             member: {
                 select: publicUserDetailSelect,
             },
+            hrPerSprint: true,
+            voyageRole: {
+                select: {
+                    name: true,
+                },
+            },
         },
     },
 };

--- a/src/teams/teams.response.ts
+++ b/src/teams/teams.response.ts
@@ -49,9 +49,20 @@ export class VoyageTeamResponse {
     updatedAt: Date;
 }
 
+class VoyageRole {
+    @ApiProperty({ example: "Developer" })
+    name: string;
+}
+
 class Member {
     @ApiProperty()
     member: PublicUserResponse;
+
+    @ApiProperty({ example: 20 })
+    hrPerSprint: number;
+
+    @ApiProperty()
+    voyageRole: VoyageRole;
 }
 
 export class PublicVoyageTeamWithUserResponse extends VoyageTeamResponse {


### PR DESCRIPTION
# Description

Just a quick fix to add hrPerSprint and voyageRole back into the teams endpoint. I refactored the code and forgot to add them back.

![image](https://github.com/chingu-x/chingu-dashboard-be/assets/6191116/d4cd7d83-4a14-41d2-bdbb-b8b7f86682b0)


## Issue link

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules