### PR TITLE
Remove Mailjet api keys secrets from deploy files and add to test.yml

### DIFF
--- a/.github/workflows/prisma-deploy-dev.yml
+++ b/.github/workflows/prisma-deploy-dev.yml
@@ -18,6 +18,4 @@ jobs:
       - name: Apply all pending migrations to the database
         run: npx prisma migrate deploy
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }},
-          MJ_APIKEY_PUBLIC: ${{ secrets.MJ_APIKEY_PUBLIC }},
-          MJ_APIKEY_PRIVATE: ${{ secrets.MJ_APIKEY_PRIVATE }}          
+          DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}

--- a/.github/workflows/prisma-deploy-prd.yml
+++ b/.github/workflows/prisma-deploy-prd.yml
@@ -18,7 +18,4 @@ jobs:
       - name: Apply all pending migrations to the database
         run: npx prisma migrate deploy
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_PRD }},
-          MJ_APIKEY_PUBLIC: ${{ secrets.MJ_APIKEY_PUBLIC }},
-          MJ_APIKEY_PRIVATE: ${{ secrets.MJ_APIKEY_PRIVATE }}
-
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PRD }}

--- a/.github/workflows/prisma-deploy-stg.yml
+++ b/.github/workflows/prisma-deploy-stg.yml
@@ -18,6 +18,4 @@ jobs:
       - name: Apply all pending migrations to the database
         run: npx prisma migrate deploy
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_STG }},
-          MJ_APIKEY_PUBLIC: ${{ secrets.MJ_APIKEY_PUBLIC }},
-          MJ_APIKEY_PRIVATE: ${{ secrets.MJ_APIKEY_PRIVATE }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL_STG }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,6 @@ jobs:
           if [ ${{ github.event.pull_request.base.ref }} == "main" ]; then
             yarn test
           fi
+        env:
+          MJ_APIKEY_PUBLIC: ${{ secrets.MJ_APIKEY_PUBLIC }},
+          MJ_APIKEY_PRIVATE: ${{ secrets.MJ_APIKEY_PRIVATE }}


### PR DESCRIPTION
# Description

Jest tests are failing on deploy to main branch because Mailjet API keys are missing from yml file.
- Add MJ_APIKEY_PUBLIC and MJ_APIKEY_PRIVATE secrets entries to test.yml file.
- Remove MJ_APIKEY_PUBLIC and MJ_APIKEY_PRIVATE from deploy prisma yml files since they were added there incorrectly.