### PR TITLE
Feature/auth tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update docker compose and scripts in package.json to include a test database container and remove usage of .env.dev to avoid confusion ([#100](https://github.com/chingu-x/chingu-dashboard-be/pull/100))
+- Restructure seed/index.ts to work with e2e tests, and add  --runInBand to e2e scripts[#101](https://github.com/chingu-x/chingu-dashboard-be/pull/101)
 
 ### Fixed
 - Fix failed tests in app and ideation due to the change from jwt token response to http cookies

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:int": "dotenv -e ./.env.test -- jest -i --no-cache --verbose --config ./test/jest-int.json",
     "test:int:docker": "dotenv -v DATABASE_URL=postgresql://chingu:chingu@postgres-test:5434/dashboard?schema=public -- jest -i --no-cache --verbose --config ./test/jest-int.json",
-    "test:e2e": "dotenv -e ./.env.test -- jest --config ./test/jest-e2e.json",
-    "test:e2e:docker": "dotenv -v DATABASE_URL=postgresql://chingu:chingu@postgres-test:5434/dashboard?schema=public -- jest --config ./test/jest-e2e.json"
+    "test:e2e": "dotenv -e ./.env.test -- jest --config ./test/jest-e2e.json --runInBand",
+    "test:e2e:docker": "dotenv -v DATABASE_URL=postgresql://chingu:chingu@postgres-test:5434/dashboard?schema=public -- jest --config ./test/jest-e2e.json --runInBand"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/prisma/seed/index.ts
+++ b/prisma/seed/index.ts
@@ -1,55 +1,7 @@
+import { seed } from "./seed";
 import { PrismaClient } from "@prisma/client";
-import * as process from "process";
-import { populateTeamResourcesAndProjectIdeas } from "./resources-project-ideas";
-import { populateTables } from "./tables";
-import { populateFormsAndResponses } from "./forms";
-import { populateVoyageTeams } from "./voyage-teams";
-import { populateUsers } from "./users";
-import { populateSprints } from "./sprints";
-import { populateMeetings } from "./meetings";
-import { populateSoloProjects } from "./solo-project";
-import { populateVoyageApplications } from "./voyage-app";
-import { populateChecklists } from "./checklist";
-import { populateVoyages } from "./voyage";
 
 const prisma = new PrismaClient();
-
-const deleteAllTables = async () => {
-    const tablenames = await prisma.$queryRaw<
-        Array<{ tablename: string }>
-    >`SELECT tablename FROM pg_tables WHERE schemaname='public'`;
-
-    const tables = tablenames
-        .map(({ tablename }) => tablename)
-        .filter((name) => name !== "_prisma_migrations")
-        .map((name) => `"public"."${name}"`)
-        .join(", ");
-
-    try {
-        await prisma.$executeRawUnsafe(
-            `TRUNCATE TABLE ${tables} RESTART IDENTITY CASCADE;`,
-        );
-    } catch (error) {
-        console.log({ error });
-    }
-    console.log("===\nAll tables deleted.\n===");
-};
-
-export const seed = async () => {
-    await deleteAllTables();
-    await populateTables(); // tables with no relations
-    await populateVoyages();
-    await populateUsers();
-    await populateSprints();
-    await populateVoyageTeams();
-    await populateTeamResourcesAndProjectIdeas();
-    await populateFormsAndResponses();
-    await populateMeetings();
-    await populateSoloProjects();
-    await populateVoyageApplications();
-    await populateChecklists();
-    console.log("===\n🌱 Database seeding completed.\n===");
-};
 
 (async function () {
     try {

--- a/prisma/seed/seed.ts
+++ b/prisma/seed/seed.ts
@@ -1,0 +1,51 @@
+import { populateTables } from "./tables";
+import { populateVoyages } from "./voyage";
+import { populateUsers } from "./users";
+import { populateSprints } from "./sprints";
+import { populateVoyageTeams } from "./voyage-teams";
+import { populateTeamResourcesAndProjectIdeas } from "./resources-project-ideas";
+import { populateFormsAndResponses } from "./forms";
+import { populateMeetings } from "./meetings";
+import { populateSoloProjects } from "./solo-project";
+import { populateVoyageApplications } from "./voyage-app";
+import { populateChecklists } from "./checklist";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export const deleteAllTables = async () => {
+    const tablenames = await prisma.$queryRaw<
+        Array<{ tablename: string }>
+    >`SELECT tablename FROM pg_tables WHERE schemaname='public'`;
+
+    const tables = tablenames
+        .map(({ tablename }) => tablename)
+        .filter((name) => name !== "_prisma_migrations")
+        .map((name) => `"public"."${name}"`)
+        .join(", ");
+
+    try {
+        await prisma.$executeRawUnsafe(
+            `TRUNCATE TABLE ${tables} RESTART IDENTITY CASCADE;`,
+        );
+    } catch (error) {
+        console.log({ error });
+    }
+    console.log("===\nAll tables deleted.\n===");
+};
+
+export const seed = async () => {
+    await deleteAllTables();
+    await populateTables(); // tables with no relations
+    await populateVoyages();
+    await populateUsers();
+    await populateSprints();
+    await populateVoyageTeams();
+    await populateTeamResourcesAndProjectIdeas();
+    await populateFormsAndResponses();
+    await populateMeetings();
+    await populateSoloProjects();
+    await populateVoyageApplications();
+    await populateChecklists();
+    console.log("===\n🌱 Database seeding completed.\n===");
+};

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -2,7 +2,6 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
 import { AppModule } from "../src/app.module";
-import * as process from "process";
 
 describe("AppController (e2e)", () => {
     let app: INestApplication;
@@ -19,7 +18,6 @@ describe("AppController (e2e)", () => {
     });
 
     it("/ (GET)", () => {
-        console.log(process.env.DATABASE_URL);
         return request(app.getHttpServer()).get("/health-check").expect(200);
     });
 });

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { INestApplication } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { AppModule } from "../src/app.module";
-import { PrismaService } from "../src/prisma/prisma.service";
+// import { PrismaService } from "../src/prisma/prisma.service";
 import { seed } from "../prisma/seed/seed";
 
 describe("AuthController e2e Tests", () => {

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,0 +1,31 @@
+import { INestApplication } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { AppModule } from "../src/app.module";
+import { PrismaService } from "../src/prisma/prisma.service";
+import { seed } from "../prisma/seed/seed";
+
+describe("AuthController e2e Tests", () => {
+    let app: INestApplication;
+    //let prisma: PrismaService;
+
+    beforeAll(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+        //prisma = moduleFixture.get<PrismaService>(PrismaService);
+
+        await seed();
+
+        app = moduleFixture.createNestApplication();
+        await app.init();
+    });
+
+    afterAll(async () => {
+        await app.close();
+    });
+
+    it("should create a new user and email verification code", async () => {
+        return true;
+        //return request(app.getHttpServer()).post("/auth/signup").expect(201);
+    });
+});


### PR DESCRIPTION
# Description

Pull seed and truncate tables functions out of seed/index.ts, so it works with e2e tests
Add --runInBand to e2e scripts so only 1 test file runs at a time (runnign them in parallel will cause seeding issues)



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature updates / changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

tested locally
![image](https://github.com/chingu-x/chingu-dashboard-be/assets/6191116/3969a1e4-094c-4a91-bf5d-77035a2746ab)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log