### PR TITLE
Auth controller e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add refresh token functionality and global guard to protect all routes ([#78](https://github.com/chingu-x/chingu-dashboard-be/pull/78))
 - Add @ApiResponse tags to ideations and features ([#65](https://github.com/chingu-x/chingu-dashboard-be/pull/77))
 - Add @ApiResponse tags to resources ([#76](https://github.com/chingu-x/chingu-dashboard-be/pull/76))
+- Add e2e tests for auth controller
 
 ### Changed
 - Update docker compose and scripts in package.json to include a test database container and remove usage of .env.dev to avoid confusion ([#100](https://github.com/chingu-x/chingu-dashboard-be/pull/100))

--- a/package.json
+++ b/package.json
@@ -28,16 +28,16 @@
     "seed": "prisma db seed",
     "lint": "eslint \"{prisma/*seed,src,test}/**/*.ts\" --fix",
     "test": "dotenv -e ./.env.test jest",
-    "test:docker": "dotenv -v DATABASE_URL=postgresql://chingu:chingu@postgres-test:5434/dashboard?schema=public jest",
+    "test:docker": "dotenv -v NODE_ENV=test -v DATABASE_URL=postgresql://chingu:chingu@postgres-test:5434/dashboard?schema=public jest",
     "test:watch": "dotenv -e ./.env.test jest --watch",
-    "test:watch:docker": "dotenv -v DATABASE_URL=postgresql://chingu:chingu@postgres-test:5434/dashboard?schema=public jest --watch",
+    "test:watch:docker": "dotenv -v NODE_ENV=test -v DATABASE_URL=postgresql://chingu:chingu@postgres-test:5434/dashboard?schema=public jest --watch",
     "test:cov": "dotenv -e ./.env.test jest --coverage",
-    "test:cov:docker": "dotenv -v DATABASE_URL=postgresql://chingu:chingu@postgres-test:5434/dashboard?schema=public jest --coverage",
+    "test:cov:docker": "dotenv -v NODE_ENV=test -v DATABASE_URL=postgresql://chingu:chingu@postgres-test:5434/dashboard?schema=public jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:int": "dotenv -e ./.env.test -- jest -i --no-cache --verbose --config ./test/jest-int.json",
-    "test:int:docker": "dotenv -v DATABASE_URL=postgresql://chingu:chingu@postgres-test:5434/dashboard?schema=public -- jest -i --no-cache --verbose --config ./test/jest-int.json",
+    "test:int:docker": "dotenv -v NODE_ENV=test -v DATABASE_URL=postgresql://chingu:chingu@postgres-test:5434/dashboard?schema=public -- jest -i --no-cache --verbose --config ./test/jest-int.json",
     "test:e2e": "dotenv -e ./.env.test -- jest --config ./test/jest-e2e.json --runInBand",
-    "test:e2e:docker": "dotenv -v DATABASE_URL=postgresql://chingu:chingu@postgres-test:5434/dashboard?schema=public -- jest --config ./test/jest-e2e.json --runInBand"
+    "test:e2e:docker": "dotenv -v NODE_ENV=test -v DATABASE_URL=postgresql://chingu:chingu@postgres-test:5434/dashboard?schema=public -- jest --config ./test/jest-e2e.json --runInBand"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
     "@types/bcrypt": "^5.0.1",
+    "@types/cookie-parser": "^1.4.6",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -264,6 +264,11 @@ export class AuthController {
         type: GenericSuccessResponse,
     })
     @ApiResponse({
+        status: HttpStatus.BAD_REQUEST,
+        description: "Error in request body, e.g. missing or invalid data",
+        type: BadRequestErrorResponse,
+    })
+    @ApiResponse({
         status: HttpStatus.UNAUTHORIZED,
         description:
             "Token error - e.g. malformed token, or expired token. <br> " +

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -165,7 +165,7 @@ export class AuthController {
     })
     @ApiResponse({
         status: HttpStatus.UNAUTHORIZED,
-        description: "JWT token error",
+        description: "Invalid / tempered access token / no refresh token",
         type: UnauthorizedErrorResponse,
     })
     @ApiResponse({
@@ -179,11 +179,6 @@ export class AuthController {
     @UseGuards(JwtRefreshAuthGuard)
     @Post("refresh")
     async refresh(@Request() req, @Res({ passthrough: true }) res) {
-        const cookies = req.cookies;
-
-        if (!cookies?.refresh_token)
-            throw new BadRequestException("No Refresh Token");
-
         const { access_token, refresh_token } = await this.authService.refresh(
             req.user,
         );

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -51,6 +51,11 @@ export class AuthController {
             "Signup Success. User created, and verification email sent.",
         type: GenericSuccessResponse,
     })
+    @ApiResponse({
+        status: HttpStatus.BAD_REQUEST,
+        description: "invalid email, password",
+        type: BadRequestErrorResponse,
+    })
     @HttpCode(HttpStatus.OK)
     @Public()
     @Post("signup")
@@ -197,12 +202,12 @@ export class AuthController {
 
     @ApiOperation({
         summary:
-            "When a user logs out, jwt token is cleared, refresh token is set to null in the database.",
+            "When a user logs out, access and refresh tokens are cleared from cookies, refresh token is set to null in the database.",
     })
     @ApiResponse({
         status: HttpStatus.OK,
         description:
-            "User successfully logs out, jwt token in cookies is removed.",
+            "User successfully logs out, access and refresh tokens in cookies is removed.",
         type: LogoutResponse,
     })
     @ApiResponse({
@@ -212,7 +217,7 @@ export class AuthController {
     })
     @ApiResponse({
         status: HttpStatus.UNAUTHORIZED,
-        description: "JWT token error",
+        description: "no access token (i.e. not logged in)",
         type: UnauthorizedErrorResponse,
     })
     @UseGuards(JwtAuthGuard)

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -66,7 +66,8 @@ export class AuthController {
     @ApiOperation({
         summary: "Resend the verification email",
         description:
-            "Please use a 'real' email if you want to receive a verification email.",
+            "Please use a 'real' email if you want to receive a verification email.<br/>" +
+            "response will always be 200, due to privacy reason",
     })
     @ApiResponse({
         status: HttpStatus.OK,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -437,6 +437,12 @@ export class AuthService {
             };
         } catch (e) {
             this.logger.debug(`[Auth/Reset Password]: error: ${e}`);
+            if (e.name === "TokenExpiredError") {
+                throw new UnauthorizedException("Reset token expired");
+            }
+            if (e.name === "JsonWebTokenError") {
+                throw new UnauthorizedException("Malformed token");
+            }
             throw e;
         }
     }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -189,7 +189,7 @@ export class AuthService {
                 const user = await this.prisma.user.findUnique({
                     where: { email: signupDto.email },
                 });
-                // if user account is not activated - send another email (replace old token)
+                // if user account is not activated - send another email (replace old token), also update the password
                 if (!user.emailVerified) {
                     const token = this.generateToken(user.id);
                     await this.prisma.emailVerificationToken.upsert({
@@ -202,6 +202,14 @@ export class AuthService {
                         create: {
                             userId: user.id,
                             token,
+                        },
+                    });
+                    await this.prisma.user.update({
+                        where: {
+                            id: user.id,
+                        },
+                        data: {
+                            password: await hashPassword(signupDto.password),
                         },
                     });
                     this.logger.debug(

--- a/src/auth/dto/signup.dto.ts
+++ b/src/auth/dto/signup.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsEmail, IsNotEmpty } from "class-validator";
+import { IsEmail, IsNotEmpty, MinLength } from "class-validator";
 
 export class SignupDto {
     @IsEmail()
@@ -10,6 +10,7 @@ export class SignupDto {
     email: string;
 
     @IsNotEmpty()
+    @MinLength(8)
     @ApiProperty({
         example: "pxpCJMSVK7Wy9rzhat",
     })

--- a/src/utils/emails/sendEmail.ts
+++ b/src/utils/emails/sendEmail.ts
@@ -1,5 +1,6 @@
 import { templateIds } from "./templateIds";
 import * as Mailjet from "node-mailjet";
+import * as process from "process";
 
 const mailjet = new Mailjet.Client({
     apiKey: process.env.MJ_APIKEY_PUBLIC,
@@ -10,6 +11,7 @@ export const sendSignupVerificationEmail = async (
     email: string,
     token: string,
 ) => {
+    if (process.env.NODE_ENV === "test") return;
     await mailjet.post("send", { version: "v3.1" }).request({
         Messages: [
             {
@@ -29,6 +31,7 @@ export const sendSignupVerificationEmail = async (
 };
 
 export const sendAttemptedRegistrationEmail = async (email: string) => {
+    if (process.env.NODE_ENV === "test") return;
     await mailjet.post("send", { version: "v3.1" }).request({
         Messages: [
             {

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,22 +1,25 @@
-import { INestApplication } from "@nestjs/common";
+import { INestApplication, ValidationPipe } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { AppModule } from "../src/app.module";
-// import { PrismaService } from "../src/prisma/prisma.service";
 import { seed } from "../prisma/seed/seed";
+import * as request from "supertest";
+import * as cookieParser from "cookie-parser";
+import { extractCookieByKey } from "./utils";
 
 describe("AuthController e2e Tests", () => {
     let app: INestApplication;
-    //let prisma: PrismaService;
+    let cookie: any;
 
     beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [AppModule],
         }).compile();
-        //prisma = moduleFixture.get<PrismaService>(PrismaService);
 
         await seed();
 
         app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe());
+        app.use(cookieParser());
         await app.init();
     });
 
@@ -24,8 +27,96 @@ describe("AuthController e2e Tests", () => {
         await app.close();
     });
 
-    it("should create a new user and email verification code", async () => {
-        return true;
-        //return request(app.getHttpServer()).post("/auth/signup").expect(201);
+    describe("Creating new users POST /auth/signup", () => {
+        const signupUrl = "/auth/signup";
+        it("should create a new user", async () => {
+            return request(app.getHttpServer())
+                .post(signupUrl)
+                .send({
+                    email: "testuser@example.com",
+                    password: "password",
+                })
+                .expect(200);
+        });
+
+        it("should return 400 when email is not valid", async () => {
+            return request(app.getHttpServer())
+                .post(signupUrl)
+                .send({})
+                .expect(400);
+        });
+
+        it("should return 400 when password is not valid", async () => {
+            return request(app.getHttpServer())
+                .post(signupUrl)
+                .send({
+                    email: "testuser@example.com",
+                    password: "short",
+                })
+                .expect(400);
+        });
+    });
+
+    describe("Log in POST auth/login", () => {
+        const loginUrl = "/auth/login";
+        it("should login and return access and refresh token", async () => {
+            return request(app.getHttpServer())
+                .post(loginUrl)
+                .send({
+                    email: "jessica.williamson@gmail.com",
+                    password: "password",
+                })
+                .expect(200)
+                .then((res) => {
+                    // extract cookie for other tests
+                    cookie = res.headers["set-cookie"];
+                    const joinedCookie = cookie.join("");
+                    expect(joinedCookie).toContain("access_token");
+                    expect(joinedCookie).toContain("refresh_token");
+                });
+        });
+
+        it("should return 400 if account does not exist", () => {
+            return request(app.getHttpServer())
+                .post(loginUrl)
+                .send({
+                    email: "notexist@example.com",
+                    password: "password",
+                })
+                .expect(400);
+        });
+
+        it("should return 401 if account exists but wrong password", () => {
+            return request(app.getHttpServer())
+                .post(loginUrl)
+                .send({
+                    email: "jessica.williamson@gmail.com",
+                    password: "wrongpassword",
+                })
+                .expect(401);
+        });
+    });
+
+    describe("Logout POST auth/logout", () => {
+        const logoutUrl = "/auth/logout";
+
+        it("should logout", async () => {
+            //console.log("cookie", cookie);
+            return request(app.getHttpServer())
+                .post(logoutUrl)
+                .set("cookie", cookie)
+                .expect(200);
+        });
+
+        it("should return 401 unauthorized if no access_token in cookie", async () => {
+            return request(app.getHttpServer()).post(logoutUrl).expect(401);
+        });
+
+        it("should return 400 if no refresh_token in cookie", async () => {
+            return request(app.getHttpServer())
+                .post(logoutUrl)
+                .set("cookie", extractCookieByKey(cookie, "access_token"))
+                .expect(400);
+        });
     });
 });

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -199,22 +199,15 @@ describe("AuthController e2e Tests", () => {
                 },
             });
 
-            // login with this user to get an access token
-            const r = await request(app.getHttpServer())
-                .post("/auth/login")
-                .send({
-                    email: newUserEmail,
-                    password: "password",
-                });
-
-            const at = extractCookieByKey(
-                r.headers["set-cookie"],
-                "access_token",
+            const { access_token } = await loginAndGetTokens(
+                newUserEmail,
+                "password",
+                app,
             );
 
             await request(app.getHttpServer())
                 .post(verifyUrl)
-                .set("Cookie", at)
+                .set("Cookie", access_token)
                 .send({
                     token: userInDb.emailVerificationToken.token,
                 })
@@ -242,22 +235,15 @@ describe("AuthController e2e Tests", () => {
                 password: "password",
             });
 
-            // login with this user to get an access token
-            const r = await request(app.getHttpServer())
-                .post("/auth/login")
-                .send({
-                    email: newUserEmail,
-                    password: "password",
-                });
-
-            const at = extractCookieByKey(
-                r.headers["set-cookie"],
-                "access_token",
+            const { access_token } = await loginAndGetTokens(
+                newUserEmail,
+                "password",
+                app,
             );
 
             await request(app.getHttpServer())
                 .post(verifyUrl)
-                .set("Cookie", at)
+                .set("Cookie", access_token)
                 .send({
                     token: "random token",
                 })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,7 +1,13 @@
+// returns just the token
 export const extractResCookieValueByKey = (cookies, key) => {
     return cookies
         .map((cookie) => {
             return cookie.split(";")[0].split("=");
         })
         .filter((cookie) => cookie[0] === key)[0][1];
+};
+
+// returns 'access_token={token}; Max-Age=1800; Path=/; Expires=Fri, 16 Feb 2024 03:17:25 GMT; HttpOnly; Secure'
+export const extractCookieByKey = (cookie, key) => {
+    return cookie.filter((cookie) => cookie.includes(key))[0];
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -975,6 +975,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie-parser@^1.4.6":
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/@types/cookie-parser/-/cookie-parser-1.4.6.tgz#002643c514cccf883a65cbe044dbdc38c0b92ade"
+  integrity sha512-KoooCrD56qlLskXPLGUiJxOMnv5l/8m7cQD2OxJ73NPMhuSz9PmvwRD6EpjDyKBVrdJDdQ4bQK7JFNHnNmax0w==
+  dependencies:
+    "@types/express" "*"
+
 "@types/cookiejar@*":
   version "2.1.2"
   resolved "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz"


### PR DESCRIPTION
# Description

Add e2e tests for auth controllers. There are also a few adjustments like
- not actually sending email when doing tests
- making password min 8 chars
- added logger for auth service instead of console.log
- added a few undocumented api responses

## Issue link

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature updates / changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Tests


# How Has This Been Tested?

`yarn test:e2e auth`

![image](https://github.com/chingu-x/chingu-dashboard-be/assets/6191116/f811cd15-0a05-4ed5-9a94-87413e79e5aa)

![image](https://github.com/chingu-x/chingu-dashboard-be/assets/6191116/f0e3a897-65f5-4ad0-ad89-1e09ea1fda37)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log