### PR TITLE
Add Meeting Ids to sprints/teams endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Another example [here](https://co-pilot.dev/changelog)
 -   Add e2e tests for forms controller ([#107](https://github.com/chingu-x/chingu-dashboard-be/pull/107))
 -   Add e2e tests for sprint controller ([#113](https://github.com/chingu-x/chingu-dashboard-be/pull/113))
 -   Add new endpoint to revoke refresh token ([#116](https://github.com/chingu-x/chingu-dashboard-be/pull/116))
+-   Add meetingId to sprints/teams endpoint (([#1169](https://github.com/chingu-x/chingu-dashboard-be/pull/119)))
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,32 +10,38 @@ Another example [here](https://co-pilot.dev/changelog)
 
 ### Added
 
--   Add @ApiResponse tags to resources ([#76](https://github.com/chingu-x/chingu-dashboard-be/pull/76))
--   Add @ApiResponse tags to ideations and features ([#65](https://github.com/chingu-x/chingu-dashboard-be/pull/77))
--   Add refresh token functionality and global guard to protect all routes ([#78](https://github.com/chingu-x/chingu-dashboard-be/pull/78))-
--   Add status to voyage table and return in /me endpoint ([#79](https://github.com/chingu-x/chingu-dashboard-be/pull/79))
--   Add github action for STG ([#81](https://github.com/chingu-x/chingu-dashboard-be/pull/81))
--   Add CHANGELOG.md ([#84](https://github.com/chingu-x/chingu-dashboard-be/pull/84))
--   Add Role/Permission guard ([#97](https://github.com/chingu-x/chingu-dashboard-be/pull/97))
--   Add e2e tests for auth controller ([#102](https://github.com/chingu-x/chingu-dashboard-be/pull/102))
--   Add e2e tests for techs controller ([#103](https://github.com/chingu-x/chingu-dashboard-be/pull/103))
--   Add check-in form database implementation and seed data ([#105](https://github.com/chingu-x/chingu-dashboard-be/pull/105))
--   Add e2e tests for forms controller ([#107](https://github.com/chingu-x/chingu-dashboard-be/pull/107))
--   Add e2e tests for sprint controller ([#113](https://github.com/chingu-x/chingu-dashboard-be/pull/113))
--   Add new endpoint to revoke refresh token ([#116](https://github.com/chingu-x/chingu-dashboard-be/pull/116))
--   Add meetingId to sprints/teams endpoint (([#1169](https://github.com/chingu-x/chingu-dashboard-be/pull/119)))
-
+- Add @ApiResponse tags to resources ([#76](https://github.com/chingu-x/chingu-dashboard-be/pull/76))
+- Add @ApiResponse tags to ideations and features ([#65](https://github.com/chingu-x/chingu-dashboard-be/pull/77))
+- Add refresh token functionality and global guard to protect all
+  routes ([#78](https://github.com/chingu-x/chingu-dashboard-be/pull/78))-
+- Add status to voyage table and return in /me endpoint ([#79](https://github.com/chingu-x/chingu-dashboard-be/pull/79))
+- Add github action for STG ([#81](https://github.com/chingu-x/chingu-dashboard-be/pull/81))
+- Add CHANGELOG.md ([#84](https://github.com/chingu-x/chingu-dashboard-be/pull/84))
+- Add Role/Permission guard ([#97](https://github.com/chingu-x/chingu-dashboard-be/pull/97))
+- Add e2e tests for auth controller ([#102](https://github.com/chingu-x/chingu-dashboard-be/pull/102))
+- Add e2e tests for techs controller ([#103](https://github.com/chingu-x/chingu-dashboard-be/pull/103))
+- Add check-in form database implementation and seed
+  data ([#105](https://github.com/chingu-x/chingu-dashboard-be/pull/105))
+- Add e2e tests for forms controller ([#107](https://github.com/chingu-x/chingu-dashboard-be/pull/107))
+- Add e2e tests for sprint controller ([#113](https://github.com/chingu-x/chingu-dashboard-be/pull/113))
+- Add new endpoint to revoke refresh token ([#116](https://github.com/chingu-x/chingu-dashboard-be/pull/116))
+- Add meetingId to sprints/teams endpoint (([#1169](https://github.com/chingu-x/chingu-dashboard-be/pull/119)))
 
 ### Changed
 
--   Update docker compose and scripts in package.json to include a test database container and remove usage of .env.dev to avoid confusion ([#100](https://github.com/chingu-x/chingu-dashboard-be/pull/100))
--   Restructure seed/index.ts to work with e2e tests, and add --runInBand to e2e scripts[#101](https://github.com/chingu-x/chingu-dashboard-be/pull/101)
--   Update changelog ([#104](https://github.com/chingu-x/chingu-dashboard-be/pull/104))
--   Update test.yml to run e2e tests on pull requests to the main branch [#105](https://github.com/chingu-x/chingu-dashboard-be/pull/105)
--   Update email templates to use domain in environment variables [#110](https://github.com/chingu-x/chingu-dashboard-be/pull/110)
+- Update docker compose and scripts in package.json to include a test database container and remove usage of .env.dev to
+  avoid confusion ([#100](https://github.com/chingu-x/chingu-dashboard-be/pull/100))
+- Restructure seed/index.ts to work with e2e tests, and add --runInBand to e2e
+  scripts[#101](https://github.com/chingu-x/chingu-dashboard-be/pull/101)
+- Update changelog ([#104](https://github.com/chingu-x/chingu-dashboard-be/pull/104))
+- Update test.yml to run e2e tests on pull requests to the main
+  branch [#105](https://github.com/chingu-x/chingu-dashboard-be/pull/105)
+- Update email templates to use domain in environment
+  variables [#110](https://github.com/chingu-x/chingu-dashboard-be/pull/110)
 
 ### Fixed
 
--   Fix failed tests in app and ideation due to the change from jwt token response to http cookies ([#98](https://github.com/chingu-x/chingu-dashboard-be/pull/98))
+- Fix failed tests in app and ideation due to the change from jwt token response to http
+  cookies ([#98](https://github.com/chingu-x/chingu-dashboard-be/pull/98))
 
 ### Removed

--- a/src/sprints/sprints.response.ts
+++ b/src/sprints/sprints.response.ts
@@ -13,6 +13,9 @@ class Sprint {
 
     @ApiProperty({ example: "2024-01-14T00:00:00.000Z" })
     endDate: Date;
+
+    @ApiProperty({ isArray: true, example: [1] })
+    teamMeetings: number;
 }
 
 export class VoyageResponse {

--- a/src/sprints/sprints.service.ts
+++ b/src/sprints/sprints.service.ts
@@ -114,6 +114,11 @@ export class SprintsService {
                         number: true,
                         startDate: true,
                         endDate: true,
+                        teamMeetings: {
+                            select: {
+                                id: true,
+                            },
+                        },
                     },
                 },
             },
@@ -138,6 +143,11 @@ export class SprintsService {
                                 number: true,
                                 startDate: true,
                                 endDate: true,
+                                teamMeetings: {
+                                    select: {
+                                        id: true,
+                                    },
+                                },
                             },
                         },
                     },


### PR DESCRIPTION
# Description

[frontend change request] Add Meeting Ids to sprints/teams endpoint so we can link the meeting Id to the sprint

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

checked responses on swagger, ran all the tests 

![image](https://github.com/chingu-x/chingu-dashboard-be/assets/6191116/6034ff00-65eb-4724-bcd1-a697af05521a)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
