### PR TITLE
feature/techs select redo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ Another example [here](https://co-pilot.dev/changelog)
 - Add e2e tests for forms controller ([#107](https://github.com/chingu-x/chingu-dashboard-be/pull/107))
 - Add e2e tests for sprint controller ([#113](https://github.com/chingu-x/chingu-dashboard-be/pull/113))
 - Add new endpoint to revoke refresh token ([#116](https://github.com/chingu-x/chingu-dashboard-be/pull/116))
-- Add meetingId to sprints/teams endpoint (([#1169](https://github.com/chingu-x/chingu-dashboard-be/pull/119)))
+- Add meetingId to sprints/teams endpoint (([#119](https://github.com/chingu-x/chingu-dashboard-be/pull/119)))
+- - Add new endpoint to select tech stack items ([#125](https://github.com/chingu-x/chingu-dashboard-be/pull/125))
 
 ### Changed
 

--- a/prisma/migrations/20240329024350_tech_select/migration.sql
+++ b/prisma/migrations/20240329024350_tech_select/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "TeamTechStackItem" ADD COLUMN     "isSelected" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -245,6 +245,7 @@ model TeamTechStackItem {
   categoryId   Int?
   voyageTeam   VoyageTeam         @relation(fields: [voyageTeamId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   voyageTeamId Int
+  isSelected   Boolean            @default(false)
 
   createdAt DateTime @default(now()) @db.Timestamptz()
   updatedAt DateTime @updatedAt

--- a/src/techs/dto/update-tech-selections.dto.ts
+++ b/src/techs/dto/update-tech-selections.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class TechSelectionDto {
+    @ApiProperty({
+        description: "tech id",
+        example: 1,
+    })
+    techId: number;
+
+    @ApiProperty({
+        description: "Selected flag",
+        example: true,
+    })
+    isSelected: boolean;
+}
+
+export class TechCategoryDto {
+    @ApiProperty({
+        description: "tech id",
+        example: 1,
+    })
+    categoryId: number;
+
+    @ApiProperty({
+        description: "Array of tech items to update 'isSelected'.",
+        type: TechSelectionDto,
+        isArray: true,
+    })
+    techs: TechSelectionDto[];
+}
+
+export class UpdateTechSelectionsDto {
+    @ApiProperty({
+        description: "Array of categories with tech selection values",
+        type: TechCategoryDto,
+        isArray: true,
+    })
+    categories: TechCategoryDto[];
+}

--- a/src/techs/techs.controller.ts
+++ b/src/techs/techs.controller.ts
@@ -2,6 +2,7 @@ import {
     Controller,
     Get,
     Post,
+    Patch,
     Body,
     Param,
     Delete,
@@ -13,6 +14,7 @@ import {
 import { TechsService } from "./techs.service";
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { CreateTeamTechDto } from "./dto/create-tech.dto";
+import { UpdateTechSelectionsDto } from "./dto/update-tech-selections.dto";
 import { TeamTechResponse, TechItemResponse } from "./techs.response";
 import {
     BadRequestErrorResponse,
@@ -180,5 +182,46 @@ export class TechsController {
         @Param("teamTechId", ParseIntPipe) teamTechId: number,
     ) {
         return this.techsService.removeVote(req, teamId, teamTechId);
+    }
+
+    @ApiOperation({
+        summary:
+            "Updates arrays of tech stack items, grouped by categoryId, sets 'isSelected' values",
+        description:
+            "Maximum of 3 selections per category allowed.  All tech items (isSelected === true/false) are required for updated categories. Login required.",
+    })
+    @ApiResponse({
+        status: HttpStatus.OK,
+        description: "Successfully updated selected tech stack items",
+        type: TechItemResponse,
+    })
+    @ApiResponse({
+        status: HttpStatus.BAD_REQUEST,
+        description: "Invalid TeamId or UserId",
+        type: BadRequestErrorResponse,
+    })
+    @ApiResponse({
+        status: HttpStatus.UNAUTHORIZED,
+        description: "Unauthorized",
+        type: UnauthorizedErrorResponse,
+    })
+    @ApiParam({
+        name: "teamId",
+        description: "voyage team Id",
+        type: "Integer",
+        required: true,
+        example: 2,
+    })
+    @Patch("/selections")
+    updateTechStackSelections(
+        @Request() req,
+        @Param("teamId", ParseIntPipe) teamId: number,
+        @Body(ValidationPipe) updateTechSelectionsDto: UpdateTechSelectionsDto,
+    ) {
+        return this.techsService.updateTechStackSelections(
+            req,
+            teamId,
+            updateTechSelectionsDto,
+        );
     }
 }

--- a/src/techs/techs.service.ts
+++ b/src/techs/techs.service.ts
@@ -6,10 +6,25 @@ import {
 } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service";
 import { CreateTeamTechDto } from "./dto/create-tech.dto";
+import { UpdateTechSelectionsDto } from "./dto/update-tech-selections.dto";
+
+const MAX_SELECTION_COUNT = 3;
 
 @Injectable()
 export class TechsService {
     constructor(private prisma: PrismaService) {}
+
+    validateTeamId = async (teamId: number) => {
+        const voyageTeam = await this.prisma.voyageTeam.findUnique({
+            where: {
+                id: teamId,
+            },
+        });
+
+        if (!voyageTeam) {
+            throw new NotFoundException(`Team (id: ${teamId}) doesn't exist.`);
+        }
+    };
 
     findVoyageMemberId = async (
         req,
@@ -28,15 +43,8 @@ export class TechsService {
     };
 
     getAllTechItemsByTeamId = async (teamId: number) => {
-        const voyageTeam = await this.prisma.voyageTeam.findUnique({
-            where: {
-                id: teamId,
-            },
-        });
+        this.validateTeamId(teamId);
 
-        if (!voyageTeam) {
-            throw new NotFoundException(`Team (id: ${teamId}) doesn't exist.`);
-        }
         return this.prisma.techStackCategory.findMany({
             select: {
                 id: true,
@@ -70,6 +78,48 @@ export class TechsService {
             },
         });
     };
+
+    async updateTechStackSelections(
+        req,
+        teamId: number,
+        updateTechSelectionsDto: UpdateTechSelectionsDto,
+    ) {
+        const categories = updateTechSelectionsDto.categories;
+
+        //count selections in categories for exceeding MAX_SELECT_COUNT
+        categories.forEach((category) => {
+            const selectCount = category.techs.reduce(
+                (acc: number, tech) => acc + (tech.isSelected ? 1 : 0),
+                0,
+            );
+            if (selectCount > MAX_SELECTION_COUNT)
+                throw new BadRequestException(
+                    `Only ${MAX_SELECTION_COUNT} selections allowed per category`,
+                );
+        });
+
+        const voyageMemberId = await this.findVoyageMemberId(req, teamId);
+        if (!voyageMemberId)
+            throw new BadRequestException("Invalid User or Team Id");
+
+        //extract techs to an array for .map
+        const techsArray: any[] = [];
+        categories.forEach((category) => {
+            category.techs.forEach((tech) => techsArray.push(tech));
+        });
+        return this.prisma.$transaction(
+            techsArray.map((tech) => {
+                return this.prisma.teamTechStackItem.update({
+                    where: {
+                        id: tech.techId,
+                    },
+                    data: {
+                        isSelected: tech.isSelected,
+                    },
+                });
+            }),
+        );
+    }
 
     async addNewTeamTech(
         req,

--- a/test/techs.e2e-spec.ts
+++ b/test/techs.e2e-spec.ts
@@ -53,8 +53,9 @@ describe("Techs Controller (e2e)", () => {
     beforeEach(async () => {
         await loginUser();
     });
-    describe("voyages/teams/:teamId/techs", () => {
-        it("GET - 200 returns array of tech categories, populated with techs and votes", async () => {
+
+    describe("GET voyages/teams/:teamId/techs - get data on all tech categories and items", () => {
+        it("should return 200 and array of tech categories, populated with techs and votes", async () => {
             const teamId: number = 2;
 
             return await request(app.getHttpServer())
@@ -108,8 +109,9 @@ describe("Techs Controller (e2e)", () => {
                     );
                 });
         });
-
-        it("POST - 201 adds new tech", async () => {
+    });
+    describe("POST voyages/teams/:teamId/techs - add new tech item", () => {
+        it("should return 201 if new tech item successfully added", async () => {
             const teamId: number = 2;
 
             return request(app.getHttpServer())
@@ -134,7 +136,7 @@ describe("Techs Controller (e2e)", () => {
                 });
         });
 
-        it("    verify that new tech is present in database", async () => {
+        it("- verify that new tech is present in database", async () => {
             const techStackItem = await prisma.teamTechStackItem.findMany({
                 where: {
                     name: newTechName,
@@ -144,7 +146,7 @@ describe("Techs Controller (e2e)", () => {
             return expect(techStackItem[0].name).toEqual(newTechName);
         });
 
-        it("POST - 401 not logged in, unauthorized", async () => {
+        it("should return 401 unauthorized if not logged in", async () => {
             const teamId: number = 2;
 
             return request(app.getHttpServer())
@@ -166,7 +168,7 @@ describe("Techs Controller (e2e)", () => {
                 });
         });
 
-        it("POST - 400 invalid teamId", async () => {
+        it("should return 400 if invalid teamId provided", async () => {
             const teamId: number = 9999999;
 
             return request(app.getHttpServer())
@@ -189,7 +191,7 @@ describe("Techs Controller (e2e)", () => {
                 });
         });
 
-        it("POST - 409 tech already exists in database", async () => {
+        it("should return 409 if tech already exists in database", async () => {
             const teamId: number = 2;
 
             return request(app.getHttpServer())
@@ -213,8 +215,8 @@ describe("Techs Controller (e2e)", () => {
         });
     });
 
-    describe("voyages/teams/:teamId/techs/:teamTechId", () => {
-        it("POST - 200 vote for tech", async () => {
+    describe("POST voyages/teams/:teamId/techs/:teamTechId - add user vote for tech item", () => {
+        it("should return 200 if vote successfully added", async () => {
             const teamId: number = 2;
             const techId: number = 3;
 
@@ -236,7 +238,7 @@ describe("Techs Controller (e2e)", () => {
                 });
         });
 
-        it("    verify that new tech vote is present in database", async () => {
+        it("- verify that new tech vote is present in database", async () => {
             const techStackVote = await prisma.teamTechStackItemVote.findMany({
                 where: {
                     teamTechId: 3,
@@ -246,7 +248,7 @@ describe("Techs Controller (e2e)", () => {
             return expect(techStackVote[0].teamMemberId).toEqual(8);
         });
 
-        it("POST - 401 not logged in, unauthorized", async () => {
+        it("should return 401 unauthorized if not logged in", async () => {
             const teamId: number = 2;
             const techId: number = 3;
 
@@ -265,7 +267,7 @@ describe("Techs Controller (e2e)", () => {
                 });
         });
 
-        it("POST - 400 invalid teamId", async () => {
+        it("should return 400 if invalid teamId provided", async () => {
             const teamId: number = 9999999;
             const techId: number = 3;
 
@@ -285,7 +287,7 @@ describe("Techs Controller (e2e)", () => {
                 });
         });
 
-        it("POST - 409 vote for tech already exists", async () => {
+        it("should return 409 if user vote for tech already exists", async () => {
             const teamId: number = 2;
             const techId: number = 3;
 
@@ -306,8 +308,8 @@ describe("Techs Controller (e2e)", () => {
         });
     });
 
-    describe("voyages/teams/:teamId/techs/:teamTechId", () => {
-        it("DELETE - 200 tech vote deleted", async () => {
+    describe("DELETE voyages/teams/:teamId/techs/:teamTechId - delete user vote for tech", () => {
+        it("should return 200 if tech vote deleted", async () => {
             const teamId: number = 2;
             const techId: number = 3;
 
@@ -329,7 +331,7 @@ describe("Techs Controller (e2e)", () => {
                 });
         });
 
-        it("    verify that new tech vote is deleted from database", async () => {
+        it("- verify that new tech vote is deleted from database", async () => {
             const techStackVote = await prisma.teamTechStackItemVote.findMany({
                 where: {
                     teamTechId: 3,
@@ -339,7 +341,7 @@ describe("Techs Controller (e2e)", () => {
             return expect(techStackVote[0]).toEqual(undefined);
         });
 
-        it("DELETE - 401 not logged in, unauthorized", async () => {
+        it("should return 401 unauthorized if not logged in", async () => {
             const teamId: number = 2;
             const techId: number = 3;
 
@@ -358,7 +360,7 @@ describe("Techs Controller (e2e)", () => {
                 });
         });
 
-        it("DELETE - 400 invalid teamId", async () => {
+        it("should return 400 if invalid teamId provided", async () => {
             const teamId: number = 99999;
             const techId: number = 3;
 
@@ -378,7 +380,7 @@ describe("Techs Controller (e2e)", () => {
                 });
         });
 
-        it("DELETE - 404 vote to delete does not exist", async () => {
+        it("should return 404 if vote to delete does not exist", async () => {
             const teamId: number = 2;
             const techId: number = 3;
 
@@ -396,6 +398,120 @@ describe("Techs Controller (e2e)", () => {
                         }),
                     );
                 });
+        });
+    });
+
+    describe("PATCH voyages/teams/:teamId/techs/selections - updates isSelected value of tech stack items", () => {
+        it("should return 200 and an array of updated techs, if successful", async () => {
+            const teamId: number = 2;
+
+            return request(app.getHttpServer())
+                .patch(`/voyages/teams/${teamId}/techs/selections`)
+                .set("Authorization", `Bearer ${userAccessToken}`)
+                .send({
+                    categories: [
+                        {
+                            categoryId: 1,
+                            techs: [
+                                {
+                                    techId: 1,
+                                    isSelected: true,
+                                },
+                            ],
+                        },
+                    ],
+                })
+                .expect(200)
+                .expect("Content-Type", /json/)
+                .expect((res) => {
+                    expect(res.body).toEqual(
+                        expect.arrayContaining([
+                            expect.objectContaining({
+                                categoryId: expect.any(Number),
+                                isSelected: expect.any(Boolean),
+                                name: expect.any(String),
+                            }),
+                        ]),
+                    );
+                });
+        });
+
+        it("should return 400 if more than 3 selections in a category", async () => {
+            const teamId: number = 2;
+
+            return request(app.getHttpServer())
+                .patch(`/voyages/teams/${teamId}/techs/selections`)
+                .set("Authorization", `Bearer ${userAccessToken}`)
+                .send({
+                    categories: [
+                        {
+                            categoryId: 1,
+                            techs: [
+                                {
+                                    techId: 1,
+                                    isSelected: true,
+                                },
+                                {
+                                    techId: 2,
+                                    isSelected: true,
+                                },
+                                {
+                                    techId: 3,
+                                    isSelected: true,
+                                },
+                                {
+                                    techId: 4,
+                                    isSelected: true,
+                                },
+                            ],
+                        },
+                    ],
+                })
+                .expect(400);
+        });
+
+        it("should return 400 invalid team id provided", async () => {
+            const teamId: number = 3;
+
+            return request(app.getHttpServer())
+                .patch(`/voyages/teams/${teamId}/techs/selections`)
+                .set("Authorization", `Bearer ${userAccessToken}`)
+                .send({
+                    categories: [
+                        {
+                            categoryId: 1,
+                            techs: [
+                                {
+                                    techId: 1,
+                                    isSelected: true,
+                                },
+                            ],
+                        },
+                    ],
+                })
+                .expect(400);
+        });
+
+        it("should return 401 unauthorized if not logged in", async () => {
+            const teamId: number = 2;
+
+            return request(app.getHttpServer())
+                .patch(`/voyages/teams/${teamId}/techs/selections`)
+                .set("Authorization", `Bearer ${undefined}`)
+                .send({
+                    categories: [
+                        {
+                            categoryId: 1,
+                            techs: [
+                                {
+                                    techId: 1,
+                                    isSelected: true,
+                                },
+                            ],
+                        },
+                    ],
+                })
+                .expect(401);
         });
     });
 });


### PR DESCRIPTION
# Description

This is a re-submission of the tech selections endpoint PR, on a fresh branch with recent updates included.  Previous issues *should be* addressed.
To apply the database changes in this PR, run `yarn migrate` and `yarn push`

This PR adds a new endpoint `voyages/teams/{teamId}/techs/selections`, allowing teams to designate tech stack items as "Selected" within their categories. It enforces a maximum of 3 selections per category, defined by `const MAX_SELECTION_COUNT`.

The teamTechStackItem model has been updated with Boolean value isSelected.


There are e2e test for the following responses:
-200 successful update
-400 max selections per category exceeded
-400 invalid teamid
-401 unauthorized- uses old JWT test

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

This has been tested in swagger and with `yarn test:e2e techs`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
