### PR TITLE
Fix bug "Auth - cannot read roles on server startup"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Another example [here](https://co-pilot.dev/changelog)
 - Fix failed tests in app and ideation due to the change from jwt token response to http cookies ([#98](https://github.com/chingu-x/chingu-dashboard-be/pull/98))
 - Fix a bug in PATCH /meetings/{meetingId}/forms/{formId} where it's not accepting an array of responese (updated validation pipe, service, and tests) ([#121](https://github.com/chingu-x/chingu-dashboard-be/pull/121))
 - Fix unit tests where mocked req doesn't match new CustomRequest type ([#122](https://github.com/chingu-x/chingu-dashboard-be/pull/122))
+- Fix bug with reading roles after reseeding causes the db to not recognize the tokens stored by the user's browser ([#134](https://github.com/chingu-x/chingu-dashboard-be/pull/134))
 
 ### Removed
 

--- a/src/auth/strategies/at.strategy.ts
+++ b/src/auth/strategies/at.strategy.ts
@@ -35,7 +35,7 @@ export class AtStrategy extends PassportStrategy(Strategy, "jwt-at") {
             userId: payload.sub,
             email: payload.email,
             roles: userInDb.roles,
-            voyageTeams: userInDb.voyageTeamMembers.map((t) => {
+            voyageTeams: userInDb.voyageTeamMembers?.map((t) => {
                 return {
                     teamId: t.voyageTeamId,
                     memberId: t.id,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -13,7 +13,7 @@ export class UsersService {
     private formatUser = (user) => {
         return {
             ...user,
-            roles: user.roles.flatMap((r) => r.role.name),
+            roles: user?.roles.flatMap((r) => r.role.name),
         };
     };
 


### PR DESCRIPTION
# Description

Added optional chaining in two places

## Issue link

Fixes [Auth - cannot read roles on server startup](https://app.clickup.com/t/86b031fb3)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
