### PR TITLE
Update response Ids - POST voyages/teams/teamId/techs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,12 @@ Another example [here](https://co-pilot.dev/changelog)
 - Update changelog ([#104](https://github.com/chingu-x/chingu-dashboard-be/pull/104))
 - Update test.yml to run e2e tests on pull requests to the main branch [#105](https://github.com/chingu-x/chingu-dashboard-be/pull/105)
 - Update email templates to use domain in environment variables [#110](https://github.com/chingu-x/chingu-dashboard-be/pull/110)
--Update /forms /forms/id response to include subQuestions [#115](https://github.com/chingu-x/chingu-dashboard-be/pull/115)
+- Update /forms /forms/id response to include subQuestions [#115](https://github.com/chingu-x/chingu-dashboard-be/pull/115)
 - Add role and permission guard to some existing routes (features, forms, ideations, teams) [#112](https://github.com/chingu-x/chingu-dashboard-be/pull/112)
 - Refactor voyages endpoint paths to follow API naming conversion [#123](https://github.com/chingu-x/chingu-dashboard-be/pull/123)
 - Refactor resources PATCH and DELETE URI [#127](https://github.com/chingu-x/chingu-dashboard-be/pull/127)
 - Modified response for GET voyages/teams/{teamId}/resources, adding user id value [#129](https://github.com/chingu-x/chingu-dashboard-be/pull/129)
+- Modified response for POST /api/v1/voyages/teams/{teamId}/techs/{teamTechId} & DELETE /api/v1/voyages/teams/{teamId}/techs/{teamTechId}, refactor id as teamTechStackItemVoteId value [#138](https://github.com/chingu-x/chingu-dashboard-be/pull/138)
 
 ### Fixed
 

--- a/src/techs/techs.controller.ts
+++ b/src/techs/techs.controller.ts
@@ -119,14 +119,14 @@ export class TechsController {
         description: "voyage team Id",
         type: "Integer",
         required: true,
-        example: 1,
+        example: 2,
     })
     @ApiParam({
         name: "teamTechId",
         description: "techId of a tech the team has select (TeamTechStackItem)",
         type: "Integer",
         required: true,
-        example: 11,
+        example: 6,
     })
     @Post("/:teamTechId")
     addExistingTechVote(
@@ -166,14 +166,14 @@ export class TechsController {
         description: "voyage team Id",
         type: "Integer",
         required: true,
-        example: 1,
+        example: 2,
     })
     @ApiParam({
         name: "teamTechId",
         description: "techId of a tech the team has select (TeamTechStackItem)",
         type: "Integer",
         required: true,
-        example: 11,
+        example: 6,
     })
     @Delete("/:teamTechId")
     removeVote(

--- a/src/techs/techs.controller.ts
+++ b/src/techs/techs.controller.ts
@@ -15,7 +15,11 @@ import { TechsService } from "./techs.service";
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { CreateTeamTechDto } from "./dto/create-tech.dto";
 import { UpdateTechSelectionsDto } from "./dto/update-tech-selections.dto";
-import { TeamTechResponse, TechItemResponse } from "./techs.response";
+import {
+    TeamTechResponse,
+    TechItemResponse,
+    TechItemDeleteResponse,
+} from "./techs.response";
 import {
     BadRequestErrorResponse,
     ConflictErrorResponse,
@@ -143,8 +147,8 @@ export class TechsController {
     @ApiResponse({
         status: HttpStatus.OK,
         description:
-            "Successfully removed a vote for an existing tech stack item by a user",
-        type: TechItemResponse,
+            "Successfully removed a vote for an existing tech stack item by a user or removes the tech stack item if no votes left",
+        type: TechItemDeleteResponse,
     })
     @ApiResponse({
         status: HttpStatus.NOT_FOUND,

--- a/src/techs/techs.response.ts
+++ b/src/techs/techs.response.ts
@@ -54,12 +54,12 @@ export class TeamTechResponse {
 
 export class TechItemResponse {
     @ApiProperty({ example: 10 })
-    id: number;
+    teamTechStackItemVotedId: number;
 
     @ApiProperty({ example: 11 })
     teamTechId: number;
 
-    @ApiProperty({ example: "Frontend" })
+    @ApiProperty({ example: 8 })
     teamMemberId: number;
 
     @ApiProperty({ example: "2023-12-01T13:55:00.611Z" })

--- a/src/techs/techs.response.ts
+++ b/src/techs/techs.response.ts
@@ -68,3 +68,11 @@ export class TechItemResponse {
     @ApiProperty({ example: "2023-12-01T13:55:00.611Z" })
     updatedAt: Date;
 }
+
+export class TechItemDeleteResponse {
+    @ApiProperty({ example: "The vote and tech stack item were deleted" })
+    message: string;
+
+    @ApiProperty({ example: 200 })
+    statusCode: number;
+}

--- a/src/techs/techs.service.ts
+++ b/src/techs/techs.service.ts
@@ -139,12 +139,20 @@ export class TechsService {
                 },
             });
 
-            return this.prisma.teamTechStackItemVote.create({
-                data: {
-                    teamTechId: newTeamTechItem.id,
-                    teamMemberId: voyageMemberId,
-                },
-            });
+            const TeamTechItemFirstVote =
+                await this.prisma.teamTechStackItemVote.create({
+                    data: {
+                        teamTechId: newTeamTechItem.id,
+                        teamMemberId: voyageMemberId,
+                    },
+                });
+            return {
+                teamTechStackItemVoteId: TeamTechItemFirstVote.id,
+                teamTechId: newTeamTechItem.id,
+                teamMemberId: TeamTechItemFirstVote.teamMemberId,
+                createdAt: TeamTechItemFirstVote.createdAt,
+                updatedAt: TeamTechItemFirstVote.updatedAt,
+            };
         } catch (e) {
             if (e.code === "P2002") {
                 throw new ConflictException(
@@ -218,20 +226,23 @@ export class TechsService {
                     },
                 },
             );
-
+            // Check if the teamTechStackItemVotes array is empty
             if (teamTechItem.teamTechStackItemVotes.length === 0) {
-                return this.prisma.teamTechStackItem.delete({
+                // If it's empty, delete the tech item from the database using Prisma ORM
+                await this.prisma.teamTechStackItem.delete({
                     where: {
                         id: teamTechId,
                     },
                 });
+
+                return {
+                    message: "The vote and tech stack item were deleted",
+                    statusCode: 200,
+                };
             } else {
                 return {
-                    teamTechStackItemVoteId: deletedVote.id,
-                    teamTechId,
-                    teamMemberId: deletedVote.teamMemberId,
-                    createdAt: deletedVote.createdAt,
-                    updatedAt: deletedVote.updatedAt,
+                    message: "This vote was deleted",
+                    statusCode: 200,
                 };
             }
         } catch (e) {

--- a/src/techs/techs.service.ts
+++ b/src/techs/techs.service.ts
@@ -156,6 +156,14 @@ export class TechsService {
     }
 
     async addExistingTechVote(req, teamId, teamTechId) {
+        // check if team tech item exists
+        const teamTechItem = await this.prisma.teamTechStackItem.findUnique({
+            where: {
+                id: teamTechId,
+            },
+        });
+        if (!teamTechItem)
+            throw new BadRequestException("Team Tech Item not found");
         const voyageMemberId = await this.findVoyageMemberId(req, teamId);
         if (!voyageMemberId) throw new BadRequestException("Invalid User");
 

--- a/src/techs/techs.service.ts
+++ b/src/techs/techs.service.ts
@@ -167,6 +167,7 @@ export class TechsService {
                         teamMemberId: voyageMemberId,
                     },
                 });
+            // If successful, it returns an object containing the details of the vote
             return {
                 teamTechStackItemVoteId: teamMemberTechVote.id,
                 teamTechId,

--- a/src/techs/techs.service.ts
+++ b/src/techs/techs.service.ts
@@ -160,12 +160,18 @@ export class TechsService {
         if (!voyageMemberId) throw new BadRequestException("Invalid User");
 
         try {
-            return await this.prisma.teamTechStackItemVote.create({
-                data: {
-                    teamTechId,
-                    teamMemberId: voyageMemberId,
-                },
-            });
+            const teamMemberTechVote =
+                await this.prisma.teamTechStackItemVote.create({
+                    data: {
+                        teamTechId,
+                        teamMemberId: voyageMemberId,
+                    },
+                });
+            return {
+                teamTechStackItemVoteId: teamMemberTechVote.id,
+                teamTechId,
+                teamMemberId: teamMemberTechVote.teamMemberId,
+            };
         } catch (e) {
             if (e.code === "P2002") {
                 throw new ConflictException(
@@ -209,7 +215,11 @@ export class TechsService {
                     },
                 });
             } else {
-                return deletedVote;
+                return {
+                    teamTechStackItemVotedId: deletedVote.id,
+                    teamTechId,
+                    teamMemberId: deletedVote.teamMemberId,
+                };
             }
         } catch (e) {
             if (e.code === "P2025") {

--- a/src/techs/techs.service.ts
+++ b/src/techs/techs.service.ts
@@ -206,7 +206,7 @@ export class TechsService {
         if (!voyageMemberId) throw new BadRequestException("Invalid User");
 
         try {
-            const deletedVote = await this.prisma.teamTechStackItemVote.delete({
+            await this.prisma.teamTechStackItemVote.delete({
                 where: {
                     userTeamStackVote: {
                         teamTechId,

--- a/src/techs/techs.service.ts
+++ b/src/techs/techs.service.ts
@@ -171,6 +171,8 @@ export class TechsService {
                 teamTechStackItemVoteId: teamMemberTechVote.id,
                 teamTechId,
                 teamMemberId: teamMemberTechVote.teamMemberId,
+                createdAt: teamMemberTechVote.createdAt,
+                updatedAt: teamMemberTechVote.updatedAt,
             };
         } catch (e) {
             if (e.code === "P2002") {
@@ -216,9 +218,11 @@ export class TechsService {
                 });
             } else {
                 return {
-                    teamTechStackItemVotedId: deletedVote.id,
+                    teamTechStackItemVoteId: deletedVote.id,
                     teamTechId,
                     teamMemberId: deletedVote.teamMemberId,
+                    createdAt: deletedVote.createdAt,
+                    updatedAt: deletedVote.updatedAt,
                 };
             }
         } catch (e) {

--- a/test/techs.e2e-spec.ts
+++ b/test/techs.e2e-spec.ts
@@ -126,7 +126,7 @@ describe("Techs Controller (e2e)", () => {
                 .expect((res) => {
                     expect(res.body).toEqual(
                         expect.objectContaining({
-                            id: expect.any(Number),
+                            teamTechStackItemVoteId: expect.any(Number),
                             teamTechId: expect.any(Number),
                             teamMemberId: expect.any(Number),
                             createdAt: expect.any(String),
@@ -321,11 +321,8 @@ describe("Techs Controller (e2e)", () => {
                 .expect((res) => {
                     expect(res.body).toEqual(
                         expect.objectContaining({
-                            teamTechStackItemVoteId: expect.any(Number),
-                            teamTechId: expect.any(Number),
-                            teamMemberId: expect.any(Number),
-                            createdAt: expect.any(String),
-                            updatedAt: expect.any(String),
+                            message: "This vote was deleted",
+                            statusCode: 200,
                         }),
                     );
                 });

--- a/test/techs.e2e-spec.ts
+++ b/test/techs.e2e-spec.ts
@@ -228,7 +228,7 @@ describe("Techs Controller (e2e)", () => {
                 .expect((res) => {
                     expect(res.body).toEqual(
                         expect.objectContaining({
-                            id: expect.any(Number),
+                            teamTechStackItemVoteId: expect.any(Number),
                             teamTechId: expect.any(Number),
                             teamMemberId: expect.any(Number),
                             createdAt: expect.any(String),
@@ -321,7 +321,7 @@ describe("Techs Controller (e2e)", () => {
                 .expect((res) => {
                     expect(res.body).toEqual(
                         expect.objectContaining({
-                            id: expect.any(Number),
+                            teamTechStackItemVoteId: expect.any(Number),
                             teamTechId: expect.any(Number),
                             teamMemberId: expect.any(Number),
                             createdAt: expect.any(String),

--- a/test/techs.e2e-spec.ts
+++ b/test/techs.e2e-spec.ts
@@ -338,6 +338,34 @@ describe("Techs Controller (e2e)", () => {
             return expect(techStackVote[0]).toEqual(undefined);
         });
 
+        it("should return 200 if tech last vote was deleted and team tech stack item is deleted", async () => {
+            const teamId: number = 2;
+            const techId: number = 9;
+            return request(app.getHttpServer())
+                .delete(`/voyages/teams/${teamId}/techs/${techId}`)
+                .set("Authorization", `Bearer ${userAccessToken}`)
+                .expect(200)
+                .expect("Content-Type", /json/)
+                .expect((res) => {
+                    expect(res.body).toEqual(
+                        expect.objectContaining({
+                            message:
+                                "The vote and tech stack item were deleted",
+                            statusCode: 200,
+                        }),
+                    );
+                });
+        });
+
+        it("- verify that tech stack Item was deleted from database", async () => {
+            const techStackItem = await prisma.teamTechStackItem.findFirst({
+                where: {
+                    name: newTechName,
+                },
+            });
+            return expect(techStackItem).toBeNull();
+        });
+
         it("should return 401 unauthorized if not logged in", async () => {
             const teamId: number = 2;
             const techId: number = 3;


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

This PR will rename the id property in the TechItemResponse class to teamTechStackItemVoteId to provide better clarity and improve semantics. The example value for the teamMemberId property has been updated to 8 to maintain consistency with other example values. The create method in the TechsService class now returns an object that includes the teamTechStackItemVoteId property for consistency. Similarly, the delete method now returns an object that includes the teamTechStackItemVoteId property for consistency.

## Issue link

Fixes # [https://app.clickup.com/t/86azw0fjm](https://app.clickup.com/t/86azw0fjm)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
In swagger:

1. run `POST /api/v1/auth/login`
2. After a successful login, run `POST /api/v1/voyages/teams/{teamId}/techs/{teamTechId}` with 'teamId: 2' and 'teamTechId: 6'. I found these two parameters worked, as the example parameters gave some errors. 
The response body should be a success like the picture below:
![Screenshot 2024-04-19 at 5 33 20 PM](https://github.com/chingu-x/chingu-dashboard-be/assets/2568193/361b8da1-8770-4554-b72f-6e0dd2fee505)


3. After voting on a tech, run `DELETE /api/v1/voyages/teams/{teamId}/techs/{teamTechId}` with the same parameters previous used. 
The response body should be a success like the picture below:
![Screenshot 2024-04-19 at 5 33 46 PM](https://github.com/chingu-x/chingu-dashboard-be/assets/2568193/b75eac30-5403-47b3-90ce-0d5e66caa134)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
