### PR TITLE
Sprint meetings -  updatedAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,7 @@ Another example [here](https://co-pilot.dev/changelog)
 - Refactor resources PATCH and DELETE URI [#127](https://github.com/chingu-x/chingu-dashboard-be/pull/127)
 - Modified response for GET voyages/teams/{teamId}/resources, adding user id value [#129](https://github.com/chingu-x/chingu-dashboard-be/pull/129)
 - updated meeting model schema to include optional description field [#135](https://github.com/chingu-x/chingu-dashboard-be/pull/135)
-
-
-
-- updated meeting model schema to include optional description field [#140](https://github.com/chingu-x/chingu-dashboard-be/pull/140)
+- updated response for route GET sprints/meetings/{meetingId} to include updatedAt for agendas [#140](https://github.com/chingu-x/chingu-dashboard-be/pull/140)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ Another example [here](https://co-pilot.dev/changelog)
 - Modified response for GET voyages/teams/{teamId}/resources, adding user id value [#129](https://github.com/chingu-x/chingu-dashboard-be/pull/129)
 - updated meeting model schema to include optional description field [#135](https://github.com/chingu-x/chingu-dashboard-be/pull/135)
 
+
+
+- updated meeting model schema to include optional description field [#140](https://github.com/chingu-x/chingu-dashboard-be/pull/140)
+
 ### Fixed
 
 - Fix failed tests in app and ideation due to the change from jwt token response to http cookies ([#98](https://github.com/chingu-x/chingu-dashboard-be/pull/98))

--- a/src/sprints/sprints.response.ts
+++ b/src/sprints/sprints.response.ts
@@ -60,7 +60,9 @@ class Agenda {
 
     @ApiProperty({ example: false })
     status: boolean;
+}
 
+class AgendaMeetingResponse extends Agenda {
     @ApiProperty({ example: "2023-11-30T06:47:11.694Z" })
     updatedAt: Date;
 }
@@ -94,7 +96,7 @@ export class MeetingResponseWithSprintAndAgenda {
     notes: string;
 
     @ApiProperty({ isArray: true })
-    agendas: Agenda;
+    agendas: AgendaMeetingResponse;
 }
 
 export class MeetingResponse {

--- a/src/sprints/sprints.response.ts
+++ b/src/sprints/sprints.response.ts
@@ -60,6 +60,9 @@ class Agenda {
 
     @ApiProperty({ example: false })
     status: boolean;
+
+    @ApiProperty({ example: "2023-11-30T06:47:11.694Z" })
+    updatedAt: Date;
 }
 
 export class MeetingResponseWithSprintAndAgenda {

--- a/src/sprints/sprints.service.ts
+++ b/src/sprints/sprints.service.ts
@@ -162,6 +162,7 @@ export class SprintsService {
                         title: true,
                         description: true,
                         status: true,
+                        updatedAt: true,
                     },
                 },
                 formResponseMeeting: {


### PR DESCRIPTION
# Description

This PR updates the response body for route GET `sprints/meetings/{meetingId}`
The 200 response now includes an `updatedAt` Date value for each item in the agendas array
No e2e tests were affected by this change

[Fixes # (86b071e68)](https://app.clickup.com/t/86b071e68)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?
Tested in swagger:
![image](https://github.com/chingu-x/chingu-dashboard-be/assets/26824124/69a4a6d8-281c-4d42-a63a-6d1212ce0941)
E2e tests:
`yarn test:e2e sprints`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
