### PR TITLE
Introduce DeleteFeatureResponse and update deleteFeature method with a status code and a message 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Another example [here](https://co-pilot.dev/changelog)
 - Update test github actions workflow with timeout [#143](https://github.com/chingu-x/chingu-dashboard-be/pull/143)
 - Refractor of all form title reference to use values from formTitle.ts [#145](https://github.com/chingu-x/chingu-dashboard-be/pull/145)
 - Update/Add more form input types [#146](https://github.com/chingu-x/chingu-dashboard-be/pull/146)
+- Update the deleteFeature method to use a DeleteFeatureResponse and return an object with a successful status and a message [#150](https://github.com/chingu-x/chingu-dashboard-be/pull/150)
 
 ### Fixed
 

--- a/src/features/features.controller.ts
+++ b/src/features/features.controller.ts
@@ -33,6 +33,7 @@ import {
     FeatureCategoriesResponse,
     ExtendedFeaturesResponse,
     FeatureResponse,
+    DeleteFeatureResponse,
 } from "./features.response";
 import { CustomRequest } from "../global/types/CustomRequest";
 
@@ -256,6 +257,7 @@ export class FeaturesController {
     @ApiResponse({
         status: HttpStatus.OK,
         description: "Successfully deleted feature.",
+        type: DeleteFeatureResponse,
     })
     //Can only delete if loggedIn userId mataches addedBy userId
     @Delete("/features/:featureId")

--- a/src/features/features.response.ts
+++ b/src/features/features.response.ts
@@ -95,3 +95,11 @@ export class ExtendedFeaturesResponse {
     @ApiProperty()
     addedBy: AddedBY;
 }
+
+export class DeleteFeatureResponse {
+    @ApiProperty({ example: "The feature was deleted successfully" })
+    message: string;
+
+    @ApiProperty({ example: 200 })
+    statusCode: number;
+}

--- a/src/features/features.service.ts
+++ b/src/features/features.service.ts
@@ -369,6 +369,11 @@ export class FeaturesService {
             throw new NotFoundException(
                 `FeatureId (id: ${featureId}) does not exist.`,
             );
+        } else {
+            return {
+                message: "Feature deleted successfully",
+                status: 200,
+            };
         }
     }
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This pull request introduces a new DeleteFeatureResponse class to handle the response for feature deletion scenarios. The class includes a message and statusCode property, which will provide a consistent and clear response when deleting a feature.
The deleteFeature method in the FeaturesService has also been updated to return an instance of the newly added DeleteFeatureResponse class. When a feature is successfully deleted, the method will return a response object with a success message and a status code of 200.

## Issue link

Fixes # [https://app.clickup.com/t/86b07bdar](https://app.clickup.com/t/86b07bdar)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Since the features don't have any tests for them yet. you have to test this endpoint in swagger by login as the default user and type `7` for the featureId, which should give a 200 response status and message. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the change log
