### PR TITLE
Added 401 responses to sprints endpoints and swagger docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Another example [here](https://co-pilot.dev/changelog)
 - Update seed files (include a time for sprint end dates, add url input type) [#151](https://github.com/chingu-x/chingu-dashboard-be/pull/151)
 - Update the deleteFeature method to use a DeleteFeatureResponse and return an object with a successful status and a message [#150](https://github.com/chingu-x/chingu-dashboard-be/pull/150)
 - Update seed data to include voyage 49-51 [#152](https://github.com/chingu-x/chingu-dashboard-be/pull/152)
+- Updated Sprints routes with 401 response when not logged in [#157](https://github.com/chingu-x/chingu-dashboard-be/pull/157)
 
 
 

--- a/src/sprints/sprints.controller.ts
+++ b/src/sprints/sprints.controller.ts
@@ -52,6 +52,11 @@ export class SprintsController {
         type: VoyageResponseWithoutMeetings,
         isArray: true,
     })
+    @ApiResponse({
+        status: HttpStatus.UNAUTHORIZED,
+        description: "User is not logged in",
+        type: UnauthorizedErrorResponse,
+    })
     getVoyagesAndSprints() {
         return this.sprintsService.getVoyagesAndSprints();
     }
@@ -70,6 +75,11 @@ export class SprintsController {
         status: HttpStatus.NOT_FOUND,
         description: "Invalid team Id. Record not found.",
         type: NotFoundErrorResponse,
+    })
+    @ApiResponse({
+        status: HttpStatus.UNAUTHORIZED,
+        description: "User is not logged in",
+        type: UnauthorizedErrorResponse,
     })
     @ApiParam({
         name: "teamId",
@@ -98,6 +108,11 @@ export class SprintsController {
         status: HttpStatus.NOT_FOUND,
         description: "Meeting with the supplied Id not found",
         type: NotFoundErrorResponse,
+    })
+    @ApiResponse({
+        status: HttpStatus.UNAUTHORIZED,
+        description: "User is not logged in",
+        type: UnauthorizedErrorResponse,
     })
     @ApiParam({
         name: "meetingId",
@@ -135,6 +150,11 @@ export class SprintsController {
         status: HttpStatus.CONFLICT,
         description: "A meeting already exist for this sprint.",
         type: ConflictErrorResponse,
+    })
+    @ApiResponse({
+        status: HttpStatus.UNAUTHORIZED,
+        description: "User is not logged in",
+        type: UnauthorizedErrorResponse,
     })
     @ApiParam({
         name: "sprintNumber",
@@ -175,6 +195,11 @@ export class SprintsController {
         description: "Invalid Meeting ID (MeetingId does not exist)",
         type: NotFoundErrorResponse,
     })
+    @ApiResponse({
+        status: HttpStatus.UNAUTHORIZED,
+        description: "User is not logged in",
+        type: UnauthorizedErrorResponse,
+    })
     @ApiParam({
         name: "meetingId",
         required: true,
@@ -205,6 +230,11 @@ export class SprintsController {
         status: HttpStatus.BAD_REQUEST,
         description: "Bad Request - Invalid Meeting ID",
         type: BadRequestErrorResponse,
+    })
+    @ApiResponse({
+        status: HttpStatus.UNAUTHORIZED,
+        description: "User is not logged in",
+        type: UnauthorizedErrorResponse,
     })
     @ApiParam({
         name: "meetingId",
@@ -237,6 +267,11 @@ export class SprintsController {
         description: "Invalid Agenda ID (AgendaId does not exist)",
         type: NotFoundErrorResponse,
     })
+    @ApiResponse({
+        status: HttpStatus.UNAUTHORIZED,
+        description: "User is not logged in",
+        type: UnauthorizedErrorResponse,
+    })
     @ApiParam({
         name: "agendaId",
         required: true,
@@ -267,6 +302,11 @@ export class SprintsController {
         status: HttpStatus.NOT_FOUND,
         description: "Invalid Agenda ID (AgendaId does not exist)",
         type: NotFoundErrorResponse,
+    })
+    @ApiResponse({
+        status: HttpStatus.UNAUTHORIZED,
+        description: "User is not logged in",
+        type: UnauthorizedErrorResponse,
     })
     @ApiParam({
         name: "agendaId",
@@ -303,6 +343,11 @@ export class SprintsController {
         status: HttpStatus.CONFLICT,
         description: `FormId and MeetingId combination should be unique. There's already an existing form of the given formId for this meeting Id`,
         type: ConflictErrorResponse,
+    })
+    @ApiResponse({
+        status: HttpStatus.UNAUTHORIZED,
+        description: "User is not logged in",
+        type: UnauthorizedErrorResponse,
     })
     @ApiParam({
         name: "meetingId",
@@ -342,6 +387,11 @@ export class SprintsController {
         status: HttpStatus.NOT_FOUND,
         description: "invalid meetingId",
         type: NotFoundErrorResponse,
+    })
+    @ApiResponse({
+        status: HttpStatus.UNAUTHORIZED,
+        description: "User is not logged in",
+        type: UnauthorizedErrorResponse,
     })
     @ApiParam({
         name: "meetingId",
@@ -398,6 +448,11 @@ export class SprintsController {
             "invalid meeting id, form id, question id(s) not found in form with a given formId, responses not an array",
         type: BadRequestErrorResponse,
     })
+    @ApiResponse({
+        status: HttpStatus.UNAUTHORIZED,
+        description: "User is not logged in",
+        type: UnauthorizedErrorResponse,
+    })
     @ApiParam({
         name: "meetingId",
         required: true,
@@ -423,6 +478,7 @@ export class SprintsController {
         );
     }
 
+    @Post("check-in")
     @ApiOperation({
         summary: "Submit end of sprint check in form",
         description:
@@ -473,7 +529,6 @@ export class SprintsController {
         description: "User has already submitted a check in for that sprint.",
         type: ConflictErrorResponse,
     })
-    @Post("check-in")
     addCheckinFormResponse(
         @Body(new FormInputValidationPipe())
         createCheckinFormResponse: CreateCheckinFormDto,

--- a/test/sprints.e2e-spec.ts
+++ b/test/sprints.e2e-spec.ts
@@ -87,10 +87,9 @@ describe("Sprints Controller (e2e)", () => {
                 });
         });
 
-        it("should return 401 if authorized token isn't present", async () => {
+        it("should return 401 if user is not logged in", async () => {
             return request(app.getHttpServer())
                 .get(`/voyages/sprints`)
-                .set("Authorization", `Bearer ${undefined}`)
                 .expect(401);
         });
     });
@@ -137,11 +136,10 @@ describe("Sprints Controller (e2e)", () => {
                 .expect(404);
         });
 
-        it("should return 401 if authorization token is not present", async () => {
+        it("should return 401 if user is not logged in", async () => {
             const teamId = 1;
             return request(app.getHttpServer())
                 .get(`/voyages/sprints/teams/${teamId}`)
-                .set("Authorization", `Bearer ${undefined}`)
                 .expect(401);
         });
     });
@@ -237,11 +235,10 @@ describe("Sprints Controller (e2e)", () => {
                 .expect(404);
         });
 
-        it("should return 401 if authorization token is not present", async () => {
+        it("should return 401 if user is not logged in", async () => {
             const meetingId = 1;
             return request(app.getHttpServer())
                 .get(`/voyages/sprints/meetings/${meetingId}`)
-                .set("Authorization", `Bearer ${undefined}`)
                 .expect(401);
         });
     });
@@ -285,6 +282,13 @@ describe("Sprints Controller (e2e)", () => {
                 },
             });
             return expect(meeting.title).toEqual("Test title");
+        });
+
+        it("should return 401 if user is not logged in", async () => {
+            const meetingId = 1;
+            return request(app.getHttpServer())
+                .patch(`/voyages/sprints/meetings/${meetingId}`)
+                .expect(401);
         });
     });
 
@@ -385,6 +389,16 @@ describe("Sprints Controller (e2e)", () => {
                 })
                 .expect(400);
         });
+
+        it("should return 401 if user is not logged in", async () => {
+            const teamId = 1;
+            const sprintNumber = 5;
+            return request(app.getHttpServer())
+                .post(
+                    `/voyages/sprints/${sprintNumber}/teams/${teamId}/meetings`,
+                )
+                .expect(401);
+        });
     });
 
     describe("POST /voyages/sprints/meetings/:meetingId/agendas - creates a new meeting agenda", () => {
@@ -437,6 +451,13 @@ describe("Sprints Controller (e2e)", () => {
                 })
                 .expect(400);
         });
+
+        it("should return 401 if user is not logged in", async () => {
+            const meetingId = 1;
+            return request(app.getHttpServer())
+                .post(`/voyages/sprints/meetings/${meetingId}/agendas`)
+                .expect(401);
+        });
     });
 
     describe("PATCH /voyages/sprints/agendas/:agendaId - supdate an agenda", () => {
@@ -488,6 +509,13 @@ describe("Sprints Controller (e2e)", () => {
                 })
                 .expect(404);
         });
+
+        it("should return 401 if user is not logged in", async () => {
+            const agendaId = 1;
+            return request(app.getHttpServer())
+                .patch(`/voyages/sprints/agendas/${agendaId}`)
+                .expect(401);
+        });
     });
     describe("DELETE /voyages/sprints/agendas/:agendaId - deletes specified agenda", () => {
         it("should return 200 and delete agenda from database", async () => {
@@ -525,6 +553,13 @@ describe("Sprints Controller (e2e)", () => {
                 .delete(`/voyages/sprints/agendas/${agendaId}`)
                 .set("Cookie", accessToken)
                 .expect(404);
+        });
+
+        it("should return 401 if user is not logged in", async () => {
+            const agendaId = 1;
+            return request(app.getHttpServer())
+                .delete(`/voyages/sprints/agendas/${agendaId}`)
+                .expect(401);
         });
     });
 
@@ -586,6 +621,14 @@ describe("Sprints Controller (e2e)", () => {
                 .set("Cookie", accessToken)
                 .expect(400);
         });
+
+        it("should return 401 if user is not logged in", async () => {
+            const meetingId = 1;
+            const formId = 999;
+            return request(app.getHttpServer())
+                .post(`/voyages/sprints/meetings/${meetingId}/forms/${formId}`)
+                .expect(401);
+        });
     });
     describe("GET /voyages/sprints/meetings/:meetingId/forms/:formId - gets meeting form", () => {
         it("should return 200 if the meeting form was successfully fetched #with responses", async () => {
@@ -643,7 +686,16 @@ describe("Sprints Controller (e2e)", () => {
                 .set("Cookie", accessToken)
                 .expect(400);
         });
+
+        it("should return 401 if user is not logged in", async () => {
+            const meetingId = 1;
+            const formId = 999;
+            return request(app.getHttpServer())
+                .get(`/voyages/sprints/meetings/${meetingId}/forms/${formId}`)
+                .expect(401);
+        });
     });
+
     describe("PATCH /voyages/sprints/meetings/:meetingId/forms/:formId - updates a meeting form", () => {
         it("should return 200 if successfully create a meeting form response", async () => {
             const meetingId = 1;
@@ -762,6 +814,14 @@ describe("Sprints Controller (e2e)", () => {
                     },
                 })
                 .expect(400);
+        });
+
+        it("should return 401 if user is not logged in", async () => {
+            const meetingId = 1;
+            const formId = 999;
+            return request(app.getHttpServer())
+                .patch(`/voyages/sprints/meetings/${meetingId}/forms/${formId}`)
+                .expect(401);
         });
     });
 


### PR DESCRIPTION
# Description

This PR adds a standard 401 response for all Sprints endpoints, when the user is not logged in.  These changes are shown in the swagger documentation and in e2e tests for all routes

## Issue link

Fixes # [86azuu45a](https://app.clickup.com/t/86azuu45a)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Verified in swagger and in sprints e2e tests


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
