### PR TITLE
Add swagger access info and form endpoint permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Another example [here](https://co-pilot.dev/changelog)
 - new command to run both e2e and unit test ([#148](https://github.com/chingu-x/chingu-dashboard-be/pull/148))
 - allow edit and delete for tech stack item([#152](https://github.com/chingu-x/chingu-dashboard-be/pull/152))
 - Add voyage project submission status to `/me` endpoint ([#158](https://github.com/chingu-x/chingu-dashboard-be/pull/158))
+- Add swagger access info, add forms authorization and e2e tests ([#160](https://github.com/chingu-x/chingu-dashboard-be/pull/160))
 
 
 ### Changed

--- a/prisma/seed/data/form-types.ts
+++ b/prisma/seed/data/form-types.ts
@@ -1,3 +1,4 @@
+// Please also update src/global/constants/formTypeId.ts after updating this file
 export default [
     {
         name: "team",

--- a/src/ability/ability.factory/ability.factory.ts
+++ b/src/ability/ability.factory/ability.factory.ts
@@ -37,9 +37,12 @@ export class AbilityFactory {
                     in: user.voyageTeams.map((vt) => vt.memberId),
                 },
             });
+            can([Action.Submit, Action.Read], "Form");
+        } else {
+            // all other users
             can([Action.Submit, Action.Read], "Form", {
                 formTypeId: {
-                    in: [formTypeId["team"], formTypeId["meeting"]],
+                    in: [formTypeId["user"]],
                 },
             });
         }

--- a/src/ability/ability.factory/ability.factory.ts
+++ b/src/ability/ability.factory/ability.factory.ts
@@ -3,6 +3,7 @@ import { AbilityBuilder, PureAbility } from "@casl/ability";
 import { PrismaSubjects } from "../prisma-generated-types";
 import { createPrismaAbility, PrismaQuery } from "@casl/prisma";
 import { UserReq } from "../../global/types/CustomRequest";
+import { formTypeId } from "../../global/constants/formTypeId";
 
 export enum Action {
     Manage = "manage",
@@ -28,13 +29,17 @@ export class AbilityFactory {
             can(Action.Manage, "all");
         } else if (user.roles.includes("voyager")) {
             can([Action.Submit], "Voyage");
-            can([Action.Read], "Form");
             can([Action.Manage], "VoyageTeam", {
                 id: { in: user.voyageTeams.map((vt) => vt.teamId) },
             });
             can([Action.Manage], "Ideation", {
                 voyageTeamMemberId: {
                     in: user.voyageTeams.map((vt) => vt.memberId),
+                },
+            });
+            can([Action.Submit, Action.Read], "Form", {
+                formTypeId: {
+                    in: [formTypeId["team"], formTypeId["meeting"]],
                 },
             });
         }

--- a/src/ability/conditions/forms.ability.ts
+++ b/src/ability/conditions/forms.ability.ts
@@ -1,6 +1,6 @@
 import { UserReq } from "../../global/types/CustomRequest";
 import { abilityFactory } from "./shared.ability";
-import { Form, Prisma } from "@prisma/client";
+import { Form } from "@prisma/client";
 import { ForbiddenError } from "@casl/ability";
 import { Action } from "../ability.factory/ability.factory";
 

--- a/src/ability/conditions/forms.ability.ts
+++ b/src/ability/conditions/forms.ability.ts
@@ -1,0 +1,17 @@
+import { UserReq } from "../../global/types/CustomRequest";
+import { abilityFactory } from "./shared.ability";
+import { Form, Prisma } from "@prisma/client";
+import { ForbiddenError } from "@casl/ability";
+import { Action } from "../ability.factory/ability.factory";
+
+// for read and submit - if they can read, they should be able to submit, so we can use the same check
+export const canReadAndSubmitForms = (user: UserReq, form: Form) => {
+    const ability = abilityFactory.defineAbility(user);
+
+    ForbiddenError.from(ability)
+        .setMessage("Cannot read or submit")
+        .throwUnlessCan(Action.Submit, {
+            ...form,
+            __caslSubjectType__: "Form",
+        });
+};

--- a/src/ability/conditions/voyage-teams.ability.ts
+++ b/src/ability/conditions/voyage-teams.ability.ts
@@ -18,13 +18,15 @@ export const manageOwnVoyageTeamWithIdParam = (
 };
 
 /***
- For future reference, this works, but it has to be of voyageTeamType without a special select statement
+ For future reference, this works, but it has to be of voyageTeamType *** without a special select statement ***
  So it should be used for cases when a team Id is not supplied (this would be an extra database query in most cases)
  but for cases when teamId is supplied as a parameter or in the req body, we can use that instead as there would
  less database query
+
+ edit 1: non basic select type seems to work for the forms endpoint, please check this
  ***/
 export const manageOwnVoyageTeam = (user: UserReq, voyageTeam: VoyageTeam) => {
-    // mockUser for testing only
+    // mockUser for testing only, normally we would get this from user
     const mockUser = {
         voyageTeams: [{ teamId: 2, memberId: 1 }],
         userId: "userId",

--- a/src/ability/prisma-generated-types.ts
+++ b/src/ability/prisma-generated-types.ts
@@ -1,6 +1,13 @@
 import { Subjects } from "@casl/prisma";
 
-import { Form, ProjectIdea, User, Voyage, VoyageTeam } from "@prisma/client";
+import {
+    Form,
+    Prisma,
+    ProjectIdea,
+    User,
+    Voyage,
+    VoyageTeam,
+} from "@prisma/client";
 
 export type PrismaSubjects = Subjects<{
     Voyage: Voyage;

--- a/src/ability/prisma-generated-types.ts
+++ b/src/ability/prisma-generated-types.ts
@@ -1,13 +1,6 @@
 import { Subjects } from "@casl/prisma";
 
-import {
-    Form,
-    Prisma,
-    ProjectIdea,
-    User,
-    Voyage,
-    VoyageTeam,
-} from "@prisma/client";
+import { Form, ProjectIdea, User, Voyage, VoyageTeam } from "@prisma/client";
 
 export type PrismaSubjects = Subjects<{
     Voyage: Voyage;

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -39,6 +39,8 @@ import { AT_MAX_AGE, RT_MAX_AGE } from "../global/constants";
 import { RevokeRTDto } from "./dto/revoke-refresh-token.dto";
 import { CheckAbilities } from "../global/decorators/abilities.decorator";
 import { Action } from "../ability/ability.factory/ability.factory";
+import { CustomRequest } from "../global/types/CustomRequest";
+import { Response } from "express";
 
 @ApiTags("Auth")
 @Controller("auth")
@@ -48,7 +50,8 @@ export class AuthController {
     @ApiOperation({
         summary: "Public Route: Signup, and send a verification email",
         description:
-            "Please use a 'real' email if you want to receive a verification email.",
+            "[access]: public" +
+            "<br>Note: Please use a 'real' email if you want to receive a verification email.",
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -71,8 +74,9 @@ export class AuthController {
     @ApiOperation({
         summary: "Resend the verification email",
         description:
-            "Please use a 'real' email if you want to receive a verification email.<br/>" +
-            "response will always be 200, due to privacy reason",
+            "[access]: unverified user, user, voyage, admin" +
+            "<br>Please use a 'real' email if you want to receive a verification email." +
+            "<br>response will always be 200, due to privacy reason",
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -92,7 +96,9 @@ export class AuthController {
 
     @ApiOperation({
         summary: "Verifies the users email",
-        description: "Using a token sent to their email when sign up",
+        description:
+            "[access]: unverified user, user, voyager, admin" +
+            "<br>Using a token sent to their email when sign up",
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -115,6 +121,7 @@ export class AuthController {
     @ApiOperation({
         summary:
             "Public Route: When a user logs in, sets access token and refresh token (http cookies).",
+        description: "<br>[access]: public",
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -140,8 +147,8 @@ export class AuthController {
     @Post("login")
     async login(
         @Body() body: LoginDto,
-        @Request() req,
-        @Res({ passthrough: true }) res,
+        @Request() req: CustomRequest,
+        @Res({ passthrough: true }) res: Response,
     ) {
         const { access_token, refresh_token } = await this.authService.login(
             req.user,
@@ -163,6 +170,7 @@ export class AuthController {
     @ApiOperation({
         summary:
             "Bypass access token jwt guard. Refresh an access token, with a valid refresh token in cookies",
+        description: "<br>[access]: public",
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -184,7 +192,10 @@ export class AuthController {
     @Public()
     @UseGuards(JwtRefreshAuthGuard)
     @Post("refresh")
-    async refresh(@Request() req, @Res({ passthrough: true }) res) {
+    async refresh(
+        @Request() req: CustomRequest,
+        @Res({ passthrough: true }) res: Response,
+    ) {
         const { access_token, refresh_token } = await this.authService.refresh(
             req.user,
         );
@@ -206,7 +217,8 @@ export class AuthController {
         summary:
             "[Admin only]: Revokes user's refresh token, with a valid user id or email",
         description:
-            "using the user's id or email, removes user's refresh token",
+            "[access]: admin" +
+            "<br>using the user's id or email, removes user's refresh token",
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -231,7 +243,7 @@ export class AuthController {
     @HttpCode(HttpStatus.OK)
     @CheckAbilities({ action: Action.Manage, subject: "all" })
     @Delete("refresh/revoke")
-    async revoke(@Body() body: RevokeRTDto, @Res() res) {
+    async revoke(@Body() body: RevokeRTDto, @Res() res: Response) {
         await this.authService.revokeRefreshToken(body);
         res.status(HttpStatus.OK).json({
             message: "User Refresh token Successfully revoke.",
@@ -242,6 +254,7 @@ export class AuthController {
     @ApiOperation({
         summary:
             "When a user logs out, access and refresh tokens are cleared from cookies, refresh token is set to null in the database.",
+        description: "[access]: user, voyager, admin",
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -261,7 +274,10 @@ export class AuthController {
     })
     @UseGuards(JwtAuthGuard)
     @Post("logout")
-    async logout(@Request() req, @Res({ passthrough: true }) res) {
+    async logout(
+        @Request() req: CustomRequest,
+        @Res({ passthrough: true }) res: Response,
+    ) {
         const cookies = req.cookies;
 
         if (!cookies?.refresh_token)
@@ -279,7 +295,8 @@ export class AuthController {
         summary:
             "Public route: Request a password reset - email with password reset link (if the account exists)",
         description:
-            "Please use a 'real' email if you want to receive a password reset email.",
+            "[access]: unverified user, user, voyager, admin" +
+            "<br>Please use a 'real' email if you want to receive a password reset email.",
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -299,7 +316,8 @@ export class AuthController {
     @ApiOperation({
         summary: "Public route: Reset user password",
         description:
-            "The reset token is emailed to them when the request a password reset.",
+            "[access]: public" +
+            "<br>The reset token is emailed to them when the request a password reset.",
     })
     @ApiResponse({
         status: HttpStatus.OK,

--- a/src/forms/forms.controller.ts
+++ b/src/forms/forms.controller.ts
@@ -57,7 +57,7 @@ export class FormsController {
     @ApiOperation({
         summary: "Gets a form with questions given a form ID",
         description:
-            "[access]: user <br>" +
+            "[access]: user (user for type), voyager, admin <br>" +
             "Returns form details of a form, with questions. <br>" +
             "This is currently for development purpose, or admin in future",
     })

--- a/src/forms/forms.controller.ts
+++ b/src/forms/forms.controller.ts
@@ -4,6 +4,7 @@ import {
     HttpStatus,
     Param,
     ParseIntPipe,
+    Request,
 } from "@nestjs/common";
 import { FormsService } from "./forms.service";
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from "@nestjs/swagger";
@@ -16,6 +17,7 @@ import {
 
 import { CheckAbilities } from "../global/decorators/abilities.decorator";
 import { Action } from "../ability/ability.factory/ability.factory";
+import { CustomRequest } from "../global/types/CustomRequest";
 
 @Controller("forms")
 @ApiTags("Forms")
@@ -26,6 +28,7 @@ export class FormsController {
     @ApiOperation({
         summary: "[Roles: admin] gets all forms from the database",
         description:
+            "[access]: admin <br>" +
             "Returns all forms details with questions. <br>" +
             "This is currently for development purpose, or admin in future",
     })
@@ -54,6 +57,7 @@ export class FormsController {
     @ApiOperation({
         summary: "Gets a form with questions given a form ID",
         description:
+            "[access]: user <br>" +
             "Returns form details of a form, with questions. <br>" +
             "This is currently for development purpose, or admin in future",
     })
@@ -79,7 +83,10 @@ export class FormsController {
         description: "form ID",
         example: 1,
     })
-    getFormById(@Param("formId", ParseIntPipe) formId: number) {
-        return this.formsService.getFormById(formId);
+    getFormById(
+        @Request() req: CustomRequest,
+        @Param("formId", ParseIntPipe) formId: number,
+    ) {
+        return this.formsService.getFormById(formId, req);
     }
 }

--- a/src/global/constants/formTypeId.ts
+++ b/src/global/constants/formTypeId.ts
@@ -1,3 +1,4 @@
+// TODO: would be nice to be able to pull this from the database on app start, once.
 export const formTypeId = {
     team: 1,
     "voyage member": 2,

--- a/src/global/constants/formTypeId.ts
+++ b/src/global/constants/formTypeId.ts
@@ -1,0 +1,6 @@
+export const formTypeId = {
+    team: 1,
+    "voyage member": 2,
+    user: 3,
+    meeting: 4,
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,9 @@ async function bootstrap() {
     if (process.env.NODE_ENV !== "production") {
         const config = new DocumentBuilder()
             .setTitle("Chingu Dashboard Project")
-            .setDescription("The api for chingu dashboard")
+            .setDescription(
+                "Chingu Dashboard API<br> default access: logged in (user)",
+            )
             .setVersion("1.0")
             .addBearerAuth()
             .addOAuth2()

--- a/src/sprints/sprints.controller.ts
+++ b/src/sprints/sprints.controller.ts
@@ -9,6 +9,7 @@ import {
     Delete,
     ValidationPipe,
     HttpStatus,
+    Request,
 } from "@nestjs/common";
 import { SprintsService } from "./sprints.service";
 import { UpdateTeamMeetingDto } from "./dto/update-team-meeting.dto";
@@ -35,6 +36,7 @@ import {
 } from "../global/responses/errors";
 import { FormResponse, ResponseResponse } from "../forms/forms.response";
 import { CreateCheckinFormDto } from "./dto/create-checkin-form.dto";
+import { CustomRequest } from "../global/types/CustomRequest";
 
 @Controller()
 @ApiTags("Voyage - Sprints")
@@ -408,10 +410,12 @@ export class SprintsController {
     getMeetingFormQuestionsWithResponses(
         @Param("meetingId", ParseIntPipe) meetingId: number,
         @Param("formId", ParseIntPipe) formId: number,
+        @Request() req: CustomRequest,
     ) {
         return this.sprintsService.getMeetingFormQuestionsWithResponses(
             meetingId,
             formId,
+            req,
         );
     }
 

--- a/src/sprints/sprints.service.ts
+++ b/src/sprints/sprints.service.ts
@@ -14,6 +14,7 @@ import { UpdateMeetingFormResponseDto } from "./dto/update-meeting-form-response
 import { CreateCheckinFormDto } from "./dto/create-checkin-form.dto";
 import { GlobalService } from "../global/global.service";
 import { FormTitles } from "../global/constants/formTitles";
+import { CustomRequest } from "../global/types/CustomRequest";
 
 @Injectable()
 export class SprintsService {
@@ -403,6 +404,7 @@ export class SprintsService {
     async getMeetingFormQuestionsWithResponses(
         meetingId: number,
         formId: number,
+        req: CustomRequest,
     ) {
         const meeting = await this.prisma.teamMeeting.findUnique({
             where: {
@@ -427,7 +429,7 @@ export class SprintsService {
 
         // this will also check if formId exist in getFormById
         if (!formResponseMeeting && (await this.isMeetingForm(formId)))
-            return this.formServices.getFormById(formId);
+            return this.formServices.getFormById(formId, req);
 
         return this.prisma.form.findUnique({
             where: {

--- a/src/teams/teams.controller.ts
+++ b/src/teams/teams.controller.ts
@@ -31,7 +31,7 @@ export class TeamsController {
 
     @ApiOperation({
         summary: "[Roles: Admin] Gets all voyage teams.",
-        description: "For development/admin purpose",
+        description: "[access]: admin <br> For development/admin purpose",
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -48,6 +48,7 @@ export class TeamsController {
     @ApiOperation({
         summary:
             "[Roles: Admin] Gets all teams for a voyage given a voyageId (int).",
+        description: "[access]: admin <br>",
     })
     // Will need to be fixed to be RESTful
     @ApiResponse({


### PR DESCRIPTION
# Description

Updated swagger endpoint descriptions for auth, and forms
Add permission to forms

Only part of the task as I don't want the PR to get to big

CASL notes for reference: https://suwanna.atlassian.net/wiki/spaces/SD/pages/76349451/CASL

Issues: 
It seems prisma/casl doesn't support matching nested values (https://casl.js.org/v5/en/guide/conditions-in-depth#match-nested-property-value)
so I have used a workaround instead

## Issue link

https://app.clickup.com/t/86azr0q42

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature updates / changes
- [x] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Tested on swagger, and `yarn test:docker`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
