### PR TITLE
Delete ideation vote and ideation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Another example [here](https://co-pilot.dev/changelog)
 - Update the deleteFeature method to use a DeleteFeatureResponse and return an object with a successful status and a message [#150](https://github.com/chingu-x/chingu-dashboard-be/pull/150)
 - Update seed data to include voyage 49-51 [#152](https://github.com/chingu-x/chingu-dashboard-be/pull/152)
 - Updated Sprints routes with 401 response when not logged in [#157](https://github.com/chingu-x/chingu-dashboard-be/pull/157)
+- Updated DELETE ideation-vote service to also delete ideation when no votes remain [#161](https://github.com/chingu-x/chingu-dashboard-be/pull/161)
 
 
 

--- a/src/ideations/ideations.service.ts
+++ b/src/ideations/ideations.service.ts
@@ -208,9 +208,41 @@ export class IdeationsService {
         }
     }
 
-    async deleteIdeation(req: CustomRequest, teamId, ideationId: number) {
-        //let voteCount: number;
+    async removeIdeation(ideationId: number) {
+        return await this.prisma.projectIdea.delete({
+            where: {
+                id: ideationId,
+            },
+        });
+    }
 
+    async removeVote(req: CustomRequest, teamId: number, ideationId: number) {
+        let ideationVote: any;
+        try {
+            const voyageTeamMemberId = this.globalService.getVoyageTeamMemberId(
+                req,
+                teamId,
+            );
+            ideationVote = await this.getIdeationVote(
+                ideationId,
+                voyageTeamMemberId,
+            );
+            return await this.prisma.projectIdeaVote.delete({
+                where: {
+                    id: ideationVote.id,
+                },
+            });
+        } catch (e) {
+            if (e.code === "P2002") {
+                throw new NotFoundException(
+                    `IdeationVote (id: ${ideationVote.id}) does not exist.`,
+                );
+            }
+            throw e;
+        }
+    }
+
+    async deleteIdeation(req: CustomRequest, teamId, ideationId: number) {
         const checkVotes = await this.getIdeationVoteCount(ideationId);
         if (checkVotes > 1) {
             throw new ConflictException(
@@ -218,8 +250,8 @@ export class IdeationsService {
             );
         }
         try {
-            //delete vote - this will also delete the ideation, since no more votes remain
-            return await this.deleteIdeationVote(req, teamId, ideationId);
+            await this.removeVote(req, teamId, ideationId);
+            return await this.removeIdeation(ideationId);
         } catch (e) {
             throw e;
         }
@@ -230,38 +262,25 @@ export class IdeationsService {
         teamId: number,
         ideationId: number,
     ) {
-        const voyageTeamMemberId = this.globalService.getVoyageTeamMemberId(
-            req,
-            teamId,
-        );
-        const ideationVote = await this.getIdeationVote(
-            ideationId,
-            voyageTeamMemberId,
-        );
         try {
-            const deleteIdeationVote = await this.prisma.projectIdeaVote.delete(
-                {
-                    where: {
-                        id: ideationVote.id,
-                    },
-                },
+            const deleteIdeationVote = await this.removeVote(
+                req,
+                teamId,
+                ideationId,
             );
             //delete ideation if no remaining votes
             const voteCount = await this.getIdeationVoteCount(ideationId);
             if (voteCount === 0) {
-                return await this.prisma.projectIdea.delete({
-                    where: {
-                        id: ideationId,
-                    },
-                });
+                await this.removeIdeation(ideationId);
             }
+
             return deleteIdeationVote;
         } catch (e) {
-            if (e.code === "P2002") {
-                throw new NotFoundException(
-                    `IdeationVote (id: ${ideationVote.id}) does not exist.`,
-                );
-            }
+            // if (e.code === "P2002") {
+            //     throw new NotFoundException(
+            //         `IdeationVote (id: ${ideationVote.id}) does not exist.`,
+            //     );
+            // }
             throw e;
         }
     }

--- a/src/ideations/ideations.service.ts
+++ b/src/ideations/ideations.service.ts
@@ -209,7 +209,7 @@ export class IdeationsService {
     }
 
     async deleteIdeation(req: CustomRequest, teamId, ideationId: number) {
-        let voteCount: number;
+        //let voteCount: number;
 
         const checkVotes = await this.getIdeationVoteCount(ideationId);
         if (checkVotes > 1) {
@@ -218,17 +218,8 @@ export class IdeationsService {
             );
         }
         try {
-            await this.deleteIdeationVote(req, teamId, ideationId);
-            voteCount = await this.getIdeationVoteCount(ideationId);
-            //only allow the user that created the idea to delete it and only if it has no votes
-            if (voteCount === 0) {
-                const deleteIdeation = await this.prisma.projectIdea.delete({
-                    where: {
-                        id: ideationId,
-                    },
-                });
-                return deleteIdeation;
-            }
+            //delete vote - this will also delete the ideation, since no more votes remain
+            return await this.deleteIdeationVote(req, teamId, ideationId);
         } catch (e) {
             throw e;
         }
@@ -255,6 +246,15 @@ export class IdeationsService {
                     },
                 },
             );
+            //delete ideation if no remaining votes
+            const voteCount = await this.getIdeationVoteCount(ideationId);
+            if (voteCount === 0) {
+                return await this.prisma.projectIdea.delete({
+                    where: {
+                        id: ideationId,
+                    },
+                });
+            }
             return deleteIdeationVote;
         } catch (e) {
             if (e.code === "P2002") {

--- a/test/ideations.e2e-spec.ts
+++ b/test/ideations.e2e-spec.ts
@@ -215,6 +215,29 @@ describe("IdeationsController (e2e)", () => {
             expect(ideationVoteCountAfter).toEqual(ideationVoteCountBefore - 1);
         });
 
+        it("should return 200 when last ideation vote, and ideation, are deleted", async () => {
+            // login to another user in the same team to vote
+            const { access_token } = await loginAndGetTokens(
+                "leo.rowe@outlook.com",
+                "password",
+                app,
+            );
+
+            await request(app.getHttpServer())
+                .delete(ideationVoteUrl)
+                .set("Cookie", access_token)
+                .expect(200);
+        });
+
+        it("- verify that deleting the last vote also deletes ideation", async () => {
+            const ideation = await prisma.projectIdea.findUnique({
+                where: {
+                    id: 1,
+                },
+            });
+            return expect(ideation).toEqual(null);
+        });
+
         it("should return 400 when removing ideation votes they didn't vote for", async () => {
             const ideationCountBefore = await prisma.projectIdea.count();
             const ideationVoteCountBefore =
@@ -265,7 +288,7 @@ describe("IdeationsController (e2e)", () => {
     });
 
     describe("/PATCH /teams/:teamId/ideations/:ideationId", () => {
-        const ideationId = 1;
+        const ideationId = 2;
         const updateIdeationUrl = `/voyages/teams/${userVoyageTeamId}/ideations/${ideationId}`;
         it("should return 200 if update is successful", async () => {
             const ideationToUpdate = await prisma.projectIdea.findUnique({
@@ -419,7 +442,7 @@ describe("IdeationsController (e2e)", () => {
 
         it("should return 201 if successfully selecting ideation", async () => {
             const teamId: number = 1;
-            const ideationId: number = 1;
+            const ideationId: number = 2;
 
             return request(app.getHttpServer())
                 .post(`/voyages/teams/${teamId}/ideations/${ideationId}/select`)
@@ -429,7 +452,7 @@ describe("IdeationsController (e2e)", () => {
 
         it("should return 409 if an ideation is already selected", async () => {
             const teamId: number = 1;
-            const ideationId: number = 1;
+            const ideationId: number = 2;
 
             try {
                 await prisma.projectIdea.update({
@@ -463,7 +486,7 @@ describe("IdeationsController (e2e)", () => {
     describe("POST /voyages/teams/:teamId/ideations/reset-selection - clears current team ideation selection", () => {
         it("should return 201 if selection successfully cleared", async () => {
             const teamId: number = 1;
-            const ideationId: number = 1;
+            const ideationId: number = 2;
             await loginAdmin();
 
             try {


### PR DESCRIPTION
# Description

This PR updates the DELETE `voyages/teams/{teamId}/ideations/{ideationId}/ideation-votes` route to also delete the corresponding ideation, if there are no more votes for it.

Notes:
Functions `deleteIdeation` and `deleteIdeationVote` have been refactored to avoid conflicting with each other 
Upated e2e tests to check deletion of ideation when last vote is deleted
Fixed conflicts with other tests

## Issue link

Fixes # [86b0fw6kn](https://app.clickup.com/t/86b0fw6kn)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature updates / changes
- [x] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

In swagger: Login, post vote for team 1, ideation 1
In Prisma Studio: delete original projectIdeaVote (id: 1)
In Swagger: delete vote for team 1, ideation 1
Check results in Studio: no projectIdeaVotes for 1 , no projectIdea 1

Tests:
`yarn test:e2e ideations`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
