### PR TITLE
Add endpoint for database reseed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Another example [here](https://co-pilot.dev/changelog)
 - Add swagger access info, add forms authorization and e2e tests ([#160](https://github.com/chingu-x/chingu-dashboard-be/pull/160))
 - Add voyages unit test, also had to update all files (seed, tests, services) to meet strict null rule due to prismaMock requirements ([#163](https://github.com/chingu-x/chingu-dashboard-be/pull/163))
 - Add e2e tests for users controller ([#165](https://github.com/chingu-x/chingu-dashboard-be/pull/165))
+- Add endpoint to reseed the database ([#170](https://github.com/chingu-x/chingu-dashboard-be/pull/170))
 
 ### Changed
 

--- a/src/HealthCheck/health-check.controller.ts
+++ b/src/HealthCheck/health-check.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get } from "@nestjs/common";
 import { Public } from "../global/decorators/public.decorator";
+import { ApiTags } from "@nestjs/swagger";
 
 @Public()
+@ApiTags("Healthchecks")
 @Controller("health-check")
 export class HealthCheckController {
     @Get("/")

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { TasksModule } from "./tasks/tasks.module";
 import { VoyagesModule } from "./voyages/voyages.module";
 import { AbilityModule } from "./ability/ability.module";
 import { AbilitiesGuard } from "./auth/guards/abilities.guard";
+import { DevelopmentModule } from "./development/development.module";
 
 @Module({
     imports: [
@@ -55,6 +56,7 @@ import { AbilitiesGuard } from "./auth/guards/abilities.guard";
         TasksModule,
         VoyagesModule,
         AbilityModule,
+        DevelopmentModule,
     ],
     controllers: [HealthCheckController],
     providers: [

--- a/src/development/development.controller.spec.ts
+++ b/src/development/development.controller.spec.ts
@@ -1,20 +1,52 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { DevelopmentController } from "./development.controller";
 import { DevelopmentService } from "./development.service";
+import * as process from "node:process";
+import { CustomRequest } from "../global/types/CustomRequest";
+import { Response } from "express";
 
 describe("DevelopmentController", () => {
     let controller: DevelopmentController;
+
+    const responseMock = {} as unknown as Response;
+
+    const mockDevelopmentService = {
+        reseedDatabase: jest.fn((_responseMock) => {
+            return {
+                message: "Mock success message",
+            };
+        }),
+    };
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
             controllers: [DevelopmentController],
             providers: [DevelopmentService],
-        }).compile();
+        })
+            .overrideProvider(DevelopmentService)
+            .useValue(mockDevelopmentService)
+            .compile();
 
         controller = module.get<DevelopmentController>(DevelopmentController);
     });
 
-    it("should be defined", () => {
+    it("development controller should be defined", () => {
         expect(controller).toBeDefined();
+    });
+
+    describe("reseed database", () => {
+        it("reedDatabase service should be defined", async () => {
+            expect(controller.reseedDatabase).toBeDefined();
+        });
+
+        it("should reseed the database", async () => {
+            expect(await controller.reseedDatabase(responseMock)).toEqual({
+                message: "Mock success message",
+            });
+
+            expect(mockDevelopmentService.reseedDatabase).toHaveBeenCalledWith(
+                responseMock,
+            );
+        });
     });
 });

--- a/src/development/development.controller.spec.ts
+++ b/src/development/development.controller.spec.ts
@@ -1,8 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { DevelopmentController } from "./development.controller";
 import { DevelopmentService } from "./development.service";
-import * as process from "node:process";
-import { CustomRequest } from "../global/types/CustomRequest";
 import { Response } from "express";
 
 describe("DevelopmentController", () => {

--- a/src/development/development.controller.spec.ts
+++ b/src/development/development.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { DevelopmentController } from "./development.controller";
+import { DevelopmentService } from "./development.service";
+
+describe("DevelopmentController", () => {
+    let controller: DevelopmentController;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [DevelopmentController],
+            providers: [DevelopmentService],
+        }).compile();
+
+        controller = module.get<DevelopmentController>(DevelopmentController);
+    });
+
+    it("should be defined", () => {
+        expect(controller).toBeDefined();
+    });
+});

--- a/src/development/development.controller.ts
+++ b/src/development/development.controller.ts
@@ -6,6 +6,7 @@ import { ReSeedSuccessResponse } from "./development.response";
 import {
     ServerErrorResponse,
     UnauthorizedErrorResponse,
+    UnprocessableEntityErrorResponse,
 } from "../global/responses/errors";
 
 @Controller("development")
@@ -16,7 +17,7 @@ export class DevelopmentController {
     @ApiOperation({
         summary: "Reseed the database",
         description:
-            "It will take a while, maybe minutes). Then you'll be logged out.",
+            "It will take a while, maybe minutes. Then you'll be logged out.",
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -27,6 +28,11 @@ export class DevelopmentController {
         status: HttpStatus.UNAUTHORIZED,
         description: "unauthorized access - not logged in",
         type: UnauthorizedErrorResponse,
+    })
+    @ApiResponse({
+        status: HttpStatus.UNPROCESSABLE_ENTITY,
+        description: "using this endpoint in non development environment.",
+        type: UnprocessableEntityErrorResponse,
     })
     @ApiResponse({
         status: HttpStatus.INTERNAL_SERVER_ERROR,

--- a/src/development/development.controller.ts
+++ b/src/development/development.controller.ts
@@ -1,7 +1,40 @@
-import { Controller } from "@nestjs/common";
+import { Controller, HttpStatus, Put, Res } from "@nestjs/common";
 import { DevelopmentService } from "./development.service";
+import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
+import { Response } from "express";
+import { ReSeedSuccessResponse } from "./development.response";
+import {
+    ServerErrorResponse,
+    UnauthorizedErrorResponse,
+} from "../global/responses/errors";
 
 @Controller("development")
+@ApiTags("Development")
 export class DevelopmentController {
     constructor(private readonly developmentService: DevelopmentService) {}
+
+    @ApiOperation({
+        summary: "Reseed the database",
+        description:
+            "It will take a while, maybe minutes). Then you'll be logged out.",
+    })
+    @ApiResponse({
+        status: HttpStatus.OK,
+        description: "Successfully reseeded the database",
+        type: ReSeedSuccessResponse,
+    })
+    @ApiResponse({
+        status: HttpStatus.UNAUTHORIZED,
+        description: "unauthorized access - not logged in",
+        type: UnauthorizedErrorResponse,
+    })
+    @ApiResponse({
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
+        description: "Reseeding failed.",
+        type: ServerErrorResponse,
+    })
+    @Put("database/reseed")
+    reseedDatabase(@Res() res: Response) {
+        return this.developmentService.reseedDatabase(res);
+    }
 }

--- a/src/development/development.controller.ts
+++ b/src/development/development.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from "@nestjs/common";
+import { DevelopmentService } from "./development.service";
+
+@Controller("development")
+export class DevelopmentController {
+    constructor(private readonly developmentService: DevelopmentService) {}
+}

--- a/src/development/development.module.ts
+++ b/src/development/development.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { DevelopmentService } from "./development.service";
+import { DevelopmentController } from "./development.controller";
+
+@Module({
+    controllers: [DevelopmentController],
+    providers: [DevelopmentService],
+})
+export class DevelopmentModule {}

--- a/src/development/development.response.ts
+++ b/src/development/development.response.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class ReSeedSuccessResponse {
+    @ApiProperty({
+        example:
+            "Database reseed successful. You are logged out. Please log in again.",
+    })
+    message: string;
+}

--- a/src/development/development.service.spec.ts
+++ b/src/development/development.service.spec.ts
@@ -1,8 +1,25 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { DevelopmentService } from "./development.service";
+import * as Seed from "../../prisma/seed/seed";
+import * as process from "node:process";
 
 describe("DevelopmentService", () => {
     let service: DevelopmentService;
+    const oldNodeEnv = process.env.NODE_ENV;
+
+    beforeAll(() => {
+        process.env.NODE_ENV = "development";
+    });
+
+    afterAll(() => {
+        process.env.NODE_ENV = oldNodeEnv;
+    });
+
+    const responseMock = {
+        json: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+        clearCookie: jest.fn().mockReturnThis(),
+    } as unknown as Response;
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
@@ -14,5 +31,13 @@ describe("DevelopmentService", () => {
 
     it("should be defined", () => {
         expect(service).toBeDefined();
+    });
+
+    it("should be able to reseed the database", async () => {
+        const seedFnMock = jest
+            .spyOn(Seed, "seed")
+            .mockImplementationOnce((): Promise<any> => Promise.resolve(null));
+        await service.reseedDatabase(responseMock);
+        expect(seedFnMock).toHaveBeenCalled();
     });
 });

--- a/src/development/development.service.spec.ts
+++ b/src/development/development.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { DevelopmentService } from "./development.service";
+
+describe("DevelopmentService", () => {
+    let service: DevelopmentService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [DevelopmentService],
+        }).compile();
+
+        service = module.get<DevelopmentService>(DevelopmentService);
+    });
+
+    it("should be defined", () => {
+        expect(service).toBeDefined();
+    });
+});

--- a/src/development/development.service.ts
+++ b/src/development/development.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class DevelopmentService {}

--- a/src/development/development.service.ts
+++ b/src/development/development.service.ts
@@ -1,4 +1,26 @@
-import { Injectable } from "@nestjs/common";
+import { HttpStatus, Injectable } from "@nestjs/common";
+import { seed } from "../../prisma/seed/seed";
 
 @Injectable()
-export class DevelopmentService {}
+export class DevelopmentService {
+    async reseedDatabase(res) {
+        try {
+            // TODO: add check to allow this only in development mode
+            await seed();
+            // logs the user out,
+            // otherwise there will be errors since logged in user will have a new uuid
+            return res
+                .status(HttpStatus.OK)
+                .clearCookie("access_token")
+                .clearCookie("refresh_token")
+                .json({
+                    message:
+                        "Database reseed successful. You are logged out. Please log in again.",
+                });
+        } catch (e) {
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+                message: `Database reseed failed: ${e.message}.`,
+            });
+        }
+    }
+}

--- a/src/development/development.service.ts
+++ b/src/development/development.service.ts
@@ -1,11 +1,21 @@
-import { HttpStatus, Injectable } from "@nestjs/common";
+import {
+    HttpStatus,
+    Injectable,
+    InternalServerErrorException,
+    UnprocessableEntityException,
+} from "@nestjs/common";
 import { seed } from "../../prisma/seed/seed";
+import * as process from "node:process";
 
 @Injectable()
 export class DevelopmentService {
     async reseedDatabase(res) {
+        if (process.env.NODE_ENV !== "development") {
+            throw new UnprocessableEntityException(
+                "Reseed failed. This endpoint can only be used in the development environment.",
+            );
+        }
         try {
-            // TODO: add check to allow this only in development mode
             await seed();
             // logs the user out,
             // otherwise there will be errors since logged in user will have a new uuid
@@ -18,9 +28,9 @@ export class DevelopmentService {
                         "Database reseed successful. You are logged out. Please log in again.",
                 });
         } catch (e) {
-            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
-                message: `Database reseed failed: ${e.message}.`,
-            });
+            throw new InternalServerErrorException(
+                `Database reseed failed: ${e.message}.`,
+            );
         }
     }
 }

--- a/src/global/responses/errors.ts
+++ b/src/global/responses/errors.ts
@@ -83,3 +83,16 @@ export class ForbiddenErrorResponse {
     @ApiProperty({ example: 403 })
     statusCode: number;
 }
+
+export class ServerErrorResponse {
+    @ApiProperty({
+        example: "Internal Server Error",
+    })
+    message: string;
+
+    @ApiPropertyOptional({ example: "Internal Server Error" })
+    error: string;
+
+    @ApiProperty({ example: 500 })
+    statusCode: number;
+}

--- a/src/global/responses/errors.ts
+++ b/src/global/responses/errors.ts
@@ -96,3 +96,19 @@ export class ServerErrorResponse {
     @ApiProperty({ example: 500 })
     statusCode: number;
 }
+
+export class UnprocessableEntityErrorResponse {
+    @ApiProperty({
+        example:
+            "This endpoint can only be used in the development environment.",
+    })
+    message: string;
+
+    @ApiPropertyOptional({
+        example: "Unprocessable Entity",
+    })
+    error: string;
+
+    @ApiProperty({ example: 422 })
+    statusCode: number;
+}

--- a/src/voyages/voyages.controller.spec.ts
+++ b/src/voyages/voyages.controller.spec.ts
@@ -63,10 +63,6 @@ describe("VoyagesController", () => {
         expect(controller).toBeDefined();
     });
 
-    it("voyages service should be defined", () => {
-        expect(controller.submitVoyageProject).toBeDefined();
-    });
-
     describe("createVoyageProjectSubmission", () => {
         it("should be defined", () => {
             expect(controller.submitVoyageProject).toBeDefined();

--- a/src/voyages/voyages.service.spec.ts
+++ b/src/voyages/voyages.service.spec.ts
@@ -49,7 +49,6 @@ describe("VoyagesService", () => {
                     provide: PrismaService,
                     useValue: prismaMock,
                 },
-                GlobalService,
                 {
                     provide: GlobalService,
                     useValue: mockGlobalService,

--- a/test/development.e2e-spec.ts
+++ b/test/development.e2e-spec.ts
@@ -1,0 +1,26 @@
+import { INestApplication } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { AppModule } from "../src/app.module";
+import cookieParser from "cookie-parser";
+
+describe("Development Controller (e2e)", () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.use(cookieParser());
+        await app.init();
+    });
+
+    afterAll(async () => {
+        await app.close();
+    });
+
+    describe("PUT /development/database/reseed", () => {
+        it("should not proceed if NODE_ENV is not development", async () => {});
+    });
+});

--- a/test/development.e2e-spec.ts
+++ b/test/development.e2e-spec.ts
@@ -12,7 +12,7 @@ describe("Development Controller (e2e)", () => {
 
     beforeAll(async () => {
         jest.resetModules();
-        // @ts-ignore
+        // @ts-expect-error: "Cannot assign to env because it is a read-only property". But you really can.
         process.env = { ...OLD_ENV };
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [AppModule],
@@ -24,7 +24,7 @@ describe("Development Controller (e2e)", () => {
     });
 
     afterAll(async () => {
-        // @ts-ignore
+        // @ts-expect-error: "Cannot assign to env because it is a read-only property". But you really can.
         process.env = OLD_ENV;
         await app.close();
     });

--- a/test/development.e2e-spec.ts
+++ b/test/development.e2e-spec.ts
@@ -1,12 +1,19 @@
 import { INestApplication } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { AppModule } from "../src/app.module";
-import cookieParser from "cookie-parser";
+import * as cookieParser from "cookie-parser";
+import { loginAndGetTokens } from "./utils";
+import * as request from "supertest";
+import * as process from "node:process";
 
 describe("Development Controller (e2e)", () => {
     let app: INestApplication;
+    const OLD_ENV = process.env;
 
     beforeAll(async () => {
+        jest.resetModules();
+        // @ts-ignore
+        process.env = { ...OLD_ENV };
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [AppModule],
         }).compile();
@@ -17,10 +24,40 @@ describe("Development Controller (e2e)", () => {
     });
 
     afterAll(async () => {
+        // @ts-ignore
+        process.env = OLD_ENV;
         await app.close();
     });
 
     describe("PUT /development/database/reseed", () => {
-        it("should not proceed if NODE_ENV is not development", async () => {});
+        it("should return 401 if user is not logged in", async () => {
+            await request(app.getHttpServer())
+                .put("/development/database/reseed")
+                .expect(401);
+        });
+        it("should return 422 and not proceed if NODE_ENV is not development", async () => {
+            const { access_token, refresh_token } = await loginAndGetTokens(
+                "jessica.williamson@gmail.com",
+                "password",
+                app,
+            );
+            await request(app.getHttpServer())
+                .put("/development/database/reseed")
+                .set("Cookie", [access_token, refresh_token])
+                .expect(422);
+        });
+
+        it("should return 200 if NODE_ENV is development", async () => {
+            const { access_token, refresh_token } = await loginAndGetTokens(
+                "jessica.williamson@gmail.com",
+                "password",
+                app,
+            );
+            process.env.NODE_ENV = "development";
+            await request(app.getHttpServer())
+                .put("/development/database/reseed")
+                .set("Cookie", [access_token, refresh_token])
+                .expect(200);
+        });
     });
 });


### PR DESCRIPTION
# Description

Add an endpoint so we can reseed the database using the API. It will only proceed if NODE_ENV=development. Added e2e tests and unit tests

## Issue link

https://app.clickup.com/t/86b0xdy8e

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature updates / changes
- [x] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Tested on swagger and `yarn test:docker`

![image](https://github.com/chingu-x/chingu-dashboard-be/assets/6191116/45f4dcc5-5cc5-4f74-82b8-8a153fc0f744)

![image](https://github.com/chingu-x/chingu-dashboard-be/assets/6191116/1308953f-e561-4682-bdad-8ef3cdfe7e3c)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
