### PR TITLE
added isSelected value to GET team techs response body

### DIFF
--- a/src/techs/techs.response.ts
+++ b/src/techs/techs.response.ts
@@ -48,6 +48,9 @@ export class TeamTechResponse {
     @ApiProperty({ example: "Frontend Stuff" })
     description: string;
 
+    @ApiProperty({ example: false })
+    isSelected: boolean;
+
     @ApiProperty({ isArray: true })
     teamTechStackItems: TeamTechStackItem;
 }

--- a/src/techs/techs.service.ts
+++ b/src/techs/techs.service.ts
@@ -76,6 +76,7 @@ export class TechsService {
                     select: {
                         id: true,
                         name: true,
+                        isSelected: true,
                         teamTechStackItemVotes: {
                             select: {
                                 votedBy: {

--- a/test/techs.e2e-spec.ts
+++ b/test/techs.e2e-spec.ts
@@ -77,6 +77,7 @@ describe("Techs Controller (e2e)", () => {
                             {
                                 id: expect.any(Number),
                                 name: expect.any(String),
+                                isSelected: expect.any(Boolean),
                                 teamTechStackItemVotes: expect.any(Array),
                             },
                         ]),


### PR DESCRIPTION
# Description

This revises the response body for GET `teams/:teamId/techs`, to include the isSelected value for techs.
1 tech test was updated

## Issue link

Fixes # ([86b15r269](https://app.clickup.com/t/86b15r269))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Tested in swagger:
-create new tech item
-select tech item
-get tech items
![image](https://github.com/chingu-x/chingu-dashboard-be/assets/26824124/883fdaa6-9662-468d-8b63-be279a3dfecb)
The both the response and the example response are updated

Tests passed:
yarn test:e2e techs



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
