### PR TITLE
Refactor ideation endpoints to remove redundant teamId params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Another example [here](https://co-pilot.dev/changelog)
 - Updated DELETE ideation-vote service to also delete ideation when no votes remain [#161](https://github.com/chingu-x/chingu-dashboard-be/pull/161)
 - Refactored the prisma models to be grouped by domain type [#172](https://github.com/chingu-x/chingu-dashboard-be/pull/172)
 - Updated response for GET teams/:teamId/techs to include isSelected value for techs [#173](https://github.com/chingu-x/chingu-dashboard-be/pull/173)
-
+- Refactor ideation endpoints to remove redundant teamId params  [#175](https://github.com/chingu-x/chingu-dashboard-be/pull/175)
 
 
 ### Fixed

--- a/src/ability/ability.factory/ability.factory.ts
+++ b/src/ability/ability.factory/ability.factory.ts
@@ -32,6 +32,9 @@ export class AbilityFactory {
             can([Action.Manage], "VoyageTeam", {
                 id: { in: user.voyageTeams.map((vt) => vt.teamId) },
             });
+            // For Ideation and Tech stack, we make the permission team based here
+            // as there are times we'll need them to be able to manage other team members ideations/tech
+            // more specific permission checks can be found in `ideations.ability.ts` etc
             can([Action.Manage], "Ideation", {
                 voyageTeamMemberId: {
                     in: user.voyageTeams.map((vt) => vt.memberId),

--- a/src/ability/conditions/ideations.ability.ts
+++ b/src/ability/conditions/ideations.ability.ts
@@ -16,7 +16,7 @@ export const manageOwnIdeationById = async (
         },
     });
     if (!ideation) {
-        throw new NotFoundException(`Ideation (id:${ideationId} not found`);
+        throw new NotFoundException(`Ideation (id:${ideationId}) not found`);
     }
     // ideation is not linked to any members, this should never happen unless the user gets deleted
     // or removed from the team?

--- a/src/ability/conditions/ideations.ability.ts
+++ b/src/ability/conditions/ideations.ability.ts
@@ -1,0 +1,38 @@
+import { UserReq } from "../../global/types/CustomRequest";
+import prisma from "../../prisma/client";
+import { ForbiddenException, NotFoundException } from "@nestjs/common";
+
+// Note: Use methods in `voyage-teams.ability.ts` to check for team ideation management
+
+// Check if the user "owns" this ideation
+export const manageOwnIdeationById = async (
+    user: UserReq,
+    ideationId: number,
+) => {
+    if (user.roles?.includes("admin")) return;
+    const ideation = await prisma.projectIdea.findUnique({
+        where: {
+            id: ideationId,
+        },
+    });
+    if (!ideation) {
+        throw new NotFoundException(`Ideation (id:${ideationId} not found`);
+    }
+    // ideation is not linked to any members, this should never happen unless the user gets deleted
+    // or removed from the team?
+    // in this case we should let the rest of the team manage it
+    if (!ideation.voyageTeamMemberId) {
+        throw new ForbiddenException(
+            `Ideation access control: You do not have sufficient permission to access this resource.`,
+        );
+    }
+    if (
+        !user.voyageTeams
+            .map((vt) => vt.memberId)
+            .includes(ideation.voyageTeamMemberId)
+    ) {
+        throw new ForbiddenException(
+            "Ideation access control: You can only manage your own ideations.",
+        );
+    }
+};

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -34,7 +34,7 @@ import { DevelopmentModule } from "./development/development.module";
                     { path: "/", module: TechsModule },
                     { path: "/", module: FeaturesModule },
                     {
-                        path: "teams/:teamId/ideations",
+                        path: "/",
                         module: IdeationsModule,
                     },
                     { path: "sprints", module: SprintsModule },

--- a/src/ideations/ideations.controller.spec.ts
+++ b/src/ideations/ideations.controller.spec.ts
@@ -74,7 +74,6 @@ describe("IdeationsController", () => {
 
     it("should create an ideation vote", async () => {
         const userId = "cc1b7a12-72f6-11ee-b962-0242ac120002";
-        const teamId = 1;
         const ideationId = 1;
         const req = {
             user: {
@@ -83,7 +82,6 @@ describe("IdeationsController", () => {
         } as CustomRequest;
         const ideationVote = await controller.createIdeationVote(
             req,
-            teamId,
             ideationId,
         );
 
@@ -112,7 +110,6 @@ describe("IdeationsController", () => {
     it("should update an ideation", async () => {
         const userId = "cc1b7a12-72f6-11ee-b962-0242ac120002";
         const ideationId = 1;
-        const teamId = 1;
         const req = {
             user: {
                 userId: userId,
@@ -126,7 +123,6 @@ describe("IdeationsController", () => {
         const ideation = await controller.updateIdeation(
             req,
             ideationId,
-            teamId,
             updateIdeationDto,
         );
         expect(service.updateIdeation).toHaveBeenCalled();
@@ -136,17 +132,12 @@ describe("IdeationsController", () => {
     it("should delete an ideation", async () => {
         const userId = "cc1b7a12-72f6-11ee-b962-0242ac120002";
         const ideationId = 1;
-        const teamId = 1;
         const req = {
             user: {
                 userId: userId,
             },
         } as CustomRequest;
-        const ideation = await controller.deleteIdeation(
-            req,
-            teamId,
-            ideationId,
-        );
+        const ideation = await controller.deleteIdeation(req, ideationId);
 
         expect(service.deleteIdeation).toHaveBeenCalled();
         expect(ideation).toBe(true);
@@ -154,7 +145,6 @@ describe("IdeationsController", () => {
 
     it("should delete an ideation vote", async () => {
         const userId = "cc1b7a12-72f6-11ee-b962-0242ac120002";
-        const teamId = 1;
         const ideationId = 1;
         const req = {
             user: {
@@ -163,7 +153,6 @@ describe("IdeationsController", () => {
         } as CustomRequest;
         const ideationVote = await controller.deleteIdeationVote(
             req,
-            teamId,
             ideationId,
         );
 

--- a/src/ideations/ideations.controller.ts
+++ b/src/ideations/ideations.controller.ts
@@ -94,17 +94,12 @@ export class IdeationsController {
         type: IdeationVoteResponse,
     })
     @CheckAbilities({ action: Action.Create, subject: "Ideation" })
-    @Post("teams/:teamId/ideations/:ideationId/ideation-votes")
+    @Post("ideations/:ideationId/ideation-votes")
     createIdeationVote(
         @Request() req: CustomRequest,
-        @Param("teamId", ParseIntPipe) teamId: number,
         @Param("ideationId", ParseIntPipe) ideationId: number,
     ) {
-        return this.ideationsService.createIdeationVote(
-            req,
-            teamId,
-            ideationId,
-        );
+        return this.ideationsService.createIdeationVote(req, ideationId);
     }
 
     @ApiOperation({

--- a/src/ideations/ideations.controller.ts
+++ b/src/ideations/ideations.controller.ts
@@ -55,7 +55,7 @@ export class IdeationsController {
         type: IdeationResponse,
     })
     @CheckAbilities({ action: Action.Create, subject: "Ideation" })
-    @Post()
+    @Post("teams/:teamId/ideations")
     createIdeation(
         @Request() req: CustomRequest,
         @Param("teamId", ParseIntPipe) teamId: number,
@@ -94,7 +94,7 @@ export class IdeationsController {
         type: IdeationVoteResponse,
     })
     @CheckAbilities({ action: Action.Create, subject: "Ideation" })
-    @Post("/:ideationId/ideation-votes")
+    @Post("teams/:teamId/ideations/:ideationId/ideation-votes")
     createIdeationVote(
         @Request() req: CustomRequest,
         @Param("teamId", ParseIntPipe) teamId: number,
@@ -122,7 +122,7 @@ export class IdeationsController {
         type: TeamIdeationsResponse,
     })
     @CheckAbilities({ action: Action.Read, subject: "Ideation" })
-    @Get()
+    @Get("teams/:teamId/ideations")
     getIdeationsByVoyageTeam(
         @Param("teamId", ParseIntPipe) teamId: number,
         @Request() req: CustomRequest,
@@ -151,17 +151,15 @@ export class IdeationsController {
         type: IdeationResponse,
     })
     @CheckAbilities({ action: Action.Update, subject: "Ideation" })
-    @Patch("/:ideationId")
+    @Patch("ideations/:ideationId")
     updateIdeation(
         @Request() req: CustomRequest,
         @Param("ideationId", ParseIntPipe) ideationId: number,
-        @Param("teamId", ParseIntPipe) teamId: number,
         @Body() updateIdeationDto: UpdateIdeationDto,
     ) {
         return this.ideationsService.updateIdeation(
             req,
             ideationId,
-            teamId,
             updateIdeationDto,
         );
     }
@@ -197,7 +195,7 @@ export class IdeationsController {
         type: ConflictErrorResponse,
     })
     @CheckAbilities({ action: Action.Delete, subject: "Ideation" })
-    @Delete("/:ideationId")
+    @Delete("teams/:teamId/ideations/:ideationId")
     deleteIdeation(
         @Request() req: CustomRequest,
         @Param("teamId", ParseIntPipe) teamId: number,
@@ -227,7 +225,7 @@ export class IdeationsController {
         type: IdeationVoteResponse,
     })
     @CheckAbilities({ action: Action.Delete, subject: "Ideation" })
-    @Delete("/:ideationId/ideation-votes")
+    @Delete("teams/:teamId/ideations/:ideationId/ideation-votes")
     deleteIdeationVote(
         @Request() req: CustomRequest,
         @Param("teamId", ParseIntPipe) teamId: number,
@@ -278,7 +276,7 @@ export class IdeationsController {
         example: 1,
     })
     @CheckAbilities({ action: Action.Manage, subject: "Ideation" })
-    @Post("/:ideationId/select")
+    @Post("teams/:teamId/ideations/:ideationId/select")
     setIdeationSelection(
         @Request() req: CustomRequest,
         @Param("teamId", ParseIntPipe) teamId: number,
@@ -318,7 +316,7 @@ export class IdeationsController {
         example: 1,
     })
     @CheckAbilities({ action: Action.Manage, subject: "all" })
-    @Post("/reset-selection")
+    @Post("teams/:teamId/ideations/reset-selection")
     resetIdeationSelection(
         @Request() req: CustomRequest,
         @Param("teamId", ParseIntPipe) teamId: number,

--- a/src/ideations/ideations.controller.ts
+++ b/src/ideations/ideations.controller.ts
@@ -195,13 +195,12 @@ export class IdeationsController {
         type: ConflictErrorResponse,
     })
     @CheckAbilities({ action: Action.Delete, subject: "Ideation" })
-    @Delete("teams/:teamId/ideations/:ideationId")
+    @Delete("ideations/:ideationId")
     deleteIdeation(
         @Request() req: CustomRequest,
-        @Param("teamId", ParseIntPipe) teamId: number,
         @Param("ideationId", ParseIntPipe) ideationId: number,
     ) {
-        return this.ideationsService.deleteIdeation(req, teamId, ideationId);
+        return this.ideationsService.deleteIdeation(req, ideationId);
     }
 
     @ApiOperation({
@@ -231,11 +230,7 @@ export class IdeationsController {
         @Param("teamId", ParseIntPipe) teamId: number,
         @Param("ideationId", ParseIntPipe) ideationId: number,
     ) {
-        return this.ideationsService.deleteIdeationVote(
-            req,
-            teamId,
-            ideationId,
-        );
+        return this.ideationsService.deleteIdeationVote(req, ideationId);
     }
 
     @ApiOperation({

--- a/src/ideations/ideations.controller.ts
+++ b/src/ideations/ideations.controller.ts
@@ -219,10 +219,9 @@ export class IdeationsController {
         type: IdeationVoteResponse,
     })
     @CheckAbilities({ action: Action.Delete, subject: "Ideation" })
-    @Delete("teams/:teamId/ideations/:ideationId/ideation-votes")
+    @Delete("ideations/:ideationId/ideation-votes")
     deleteIdeationVote(
         @Request() req: CustomRequest,
-        @Param("teamId", ParseIntPipe) teamId: number,
         @Param("ideationId", ParseIntPipe) ideationId: number,
     ) {
         return this.ideationsService.deleteIdeationVote(req, ideationId);

--- a/src/ideations/ideations.service.ts
+++ b/src/ideations/ideations.service.ts
@@ -194,7 +194,7 @@ export class IdeationsService {
         });
     }
 
-    async removeVote(req: CustomRequest, teamId: number, ideationId: number) {
+    async removeVote(req: CustomRequest, ideationId: number) {
         try {
             const ideationVote = await this.prisma.projectIdeaVote.findFirst({
                 where: {
@@ -227,11 +227,7 @@ export class IdeationsService {
         }
     }
 
-    async deleteIdeation(
-        req: CustomRequest,
-        teamId: number,
-        ideationId: number,
-    ) {
+    async deleteIdeation(req: CustomRequest, ideationId: number) {
         const checkVotes = await this.getIdeationVoteCount(ideationId);
         if (checkVotes > 1) {
             throw new ConflictException(
@@ -239,24 +235,16 @@ export class IdeationsService {
             );
         }
         try {
-            await this.removeVote(req, teamId, ideationId);
+            await this.removeVote(req, ideationId);
             return await this.removeIdeation(ideationId);
         } catch (e) {
             throw e;
         }
     }
 
-    async deleteIdeationVote(
-        req: CustomRequest,
-        teamId: number,
-        ideationId: number,
-    ) {
+    async deleteIdeationVote(req: CustomRequest, ideationId: number) {
         try {
-            const deleteIdeationVote = await this.removeVote(
-                req,
-                teamId,
-                ideationId,
-            );
+            const deleteIdeationVote = await this.removeVote(req, ideationId);
             //delete ideation if no remaining votes
             const voteCount = await this.getIdeationVoteCount(ideationId);
             if (voteCount === 0) {
@@ -265,11 +253,6 @@ export class IdeationsService {
 
             return deleteIdeationVote;
         } catch (e) {
-            // if (e.code === "P2002") {
-            //     throw new NotFoundException(
-            //         `IdeationVote (id: ${ideationVote.id}) does not exist.`,
-            //     );
-            // }
             throw e;
         }
     }

--- a/src/ideations/ideations.service.ts
+++ b/src/ideations/ideations.service.ts
@@ -199,13 +199,12 @@ export class IdeationsService {
             const userHasVoted = await this.hasIdeationVote(req, ideationId);
             //if user has not voted then a vote can be created
             if (!userHasVoted) {
-                const createVote = await this.prisma.projectIdeaVote.create({
+                return this.prisma.projectIdeaVote.create({
                     data: {
                         voyageTeamMemberId,
                         projectIdeaId: ideationId,
                     },
                 });
-                return createVote;
             } else {
                 throw new ConflictException(
                     `User has already voted for ideationId: ${ideationId}`,

--- a/test/ideations.e2e-spec.ts
+++ b/test/ideations.e2e-spec.ts
@@ -134,9 +134,9 @@ describe("IdeationsController (e2e)", () => {
         });
     });
 
-    describe("/POST voyages/teams/:teamId/ideations/:ideationId/ideation-votes", () => {
+    describe("/POST voyages/ideations/:ideationId/ideation-votes", () => {
         const ideationId = 1;
-        const ideationVoteUrl = `/voyages/teams/${userVoyageTeamId}/ideations/${ideationId}/ideation-votes`;
+        const ideationVoteUrl = `/voyages/ideations/${ideationId}/ideation-votes`;
 
         it("should return 201 if an ideation vote is successfully created", async () => {
             // login to another user in the same team to vote
@@ -173,15 +173,20 @@ describe("IdeationsController (e2e)", () => {
         });
 
         it("should return 403 when user is voting for another ideation which belongs to another team", async () => {
+            const { access_token } = await loginAndGetTokens(
+                "JosoMadar@dayrep.com",
+                "password",
+                app,
+            );
             await request(app.getHttpServer())
-                .post(`/voyages/teams/2/ideations/4/ideation-votes`)
-                .set("Cookie", accessToken)
+                .post(`/voyages/ideations/4/ideation-votes`)
+                .set("Cookie", access_token)
                 .expect(403);
         });
 
         it("should return 404 when the ideation ID doesn't exist", async () => {
             await request(app.getHttpServer())
-                .post(`/voyages/teams/1/ideations/20/ideation-votes`)
+                .post(`/voyages/ideations/20/ideation-votes`)
                 .set("Cookie", accessToken)
                 .expect(404);
         });
@@ -401,7 +406,7 @@ describe("IdeationsController (e2e)", () => {
             );
 
             await request(app.getHttpServer())
-                .post(`/voyages/teams/1/ideations/2/ideation-votes`)
+                .post(`/voyages/ideations/2/ideation-votes`)
                 .set("Cookie", access_token)
                 .expect(201);
 

--- a/test/ideations.e2e-spec.ts
+++ b/test/ideations.e2e-spec.ts
@@ -287,9 +287,9 @@ describe("IdeationsController (e2e)", () => {
         });
     });
 
-    describe("/PATCH /teams/:teamId/ideations/:ideationId", () => {
+    describe("/PATCH /ideations/:ideationId", () => {
         const ideationId = 2;
-        const updateIdeationUrl = `/voyages/teams/${userVoyageTeamId}/ideations/${ideationId}`;
+        const updateIdeationUrl = `/voyages/ideations/${ideationId}`;
         it("should return 200 if update is successful", async () => {
             const ideationToUpdate = await prisma.projectIdea.findUnique({
                 where: { id: ideationId },
@@ -314,29 +314,22 @@ describe("IdeationsController (e2e)", () => {
                 .expect(200);
         });
 
-        it("should return 400 when ideation Id is not in the specified team", async () => {
-            await request(app.getHttpServer())
-                .patch(`/voyages/teams/2/ideations/1`)
-                .set("Cookie", accessToken)
-                .expect(400);
-        });
-
         it("should return 401 when user is not logged in", async () => {
             await request(app.getHttpServer())
                 .patch(updateIdeationUrl)
                 .expect(401);
         });
 
-        it("should return 403 when user tries to delete someone else's ideation in the same team", async () => {
+        it("should return 403 when user tries to update someone else's ideation in the same team", async () => {
             await request(app.getHttpServer())
-                .patch(`/voyages/teams/${userVoyageTeamId}/ideations/8`)
+                .patch(`/voyages/ideations/8`)
                 .set("Cookie", accessToken)
                 .expect(403);
         });
 
         it("should return 404 when ideation Id does not exist", async () => {
             await request(app.getHttpServer())
-                .patch(`/voyages/teams/1/ideations/100`)
+                .patch(`/voyages/ideations/100`)
                 .set("Cookie", accessToken)
                 .expect(404);
         });

--- a/test/ideations.e2e-spec.ts
+++ b/test/ideations.e2e-spec.ts
@@ -359,8 +359,6 @@ describe("IdeationsController (e2e)", () => {
             expect(ideationVoteCountAfter).toEqual(ideationVoteCountBefore - 1);
         });
 
-        // user cannot delete someone else's ideation
-        // Add a 403 test
         it("should return 400 if the user delete their own ideation with other votes", async () => {
             const ideationCountBefore = await prisma.projectIdea.count();
             const ideationVoteCountBefore =
@@ -384,7 +382,6 @@ describe("IdeationsController (e2e)", () => {
                 .expect(401);
         });
 
-        // Should be 404
         it("should return 404 if ideation Id does not exist", async () => {
             await request(app.getHttpServer())
                 .delete(`/voyages/ideations/200`)

--- a/test/ideations.e2e-spec.ts
+++ b/test/ideations.e2e-spec.ts
@@ -384,11 +384,11 @@ describe("IdeationsController (e2e)", () => {
         });
 
         // Should be 404
-        it("should return 400 if ideation Id does not exist", async () => {
+        it("should return 404 if ideation Id does not exist", async () => {
             await request(app.getHttpServer())
                 .delete(`/voyages/ideations/200`)
                 .set("Cookie", accessToken)
-                .expect(400);
+                .expect(404);
         });
 
         // user cannot delete ideation with votes in it

--- a/test/ideations.e2e-spec.ts
+++ b/test/ideations.e2e-spec.ts
@@ -199,9 +199,9 @@ describe("IdeationsController (e2e)", () => {
         });
     });
 
-    describe("/DELETE voyages/teams/:teamId/ideations/:ideationId/ideation-votes", () => {
+    describe("/DELETE voyages/ideations/:ideationId/ideation-votes", () => {
         const ideationId = 1;
-        const ideationVoteUrl = `/voyages/teams/${userVoyageTeamId}/ideations/${ideationId}/ideation-votes`;
+        const ideationVoteUrl = `/voyages/ideations/${ideationId}/ideation-votes`;
 
         it("should return 200 when ideation vote is deleted", async () => {
             const ideationCountBefore = await prisma.projectIdea.count();
@@ -248,9 +248,7 @@ describe("IdeationsController (e2e)", () => {
             const ideationVoteCountBefore =
                 await prisma.projectIdeaVote.count();
             await request(app.getHttpServer())
-                .delete(
-                    `/voyages/teams/${userVoyageTeamId}/ideations/8/ideation-votes`,
-                )
+                .delete(`/voyages/ideations/8/ideation-votes`)
                 .set("Cookie", accessToken)
                 .expect(400);
 
@@ -264,9 +262,7 @@ describe("IdeationsController (e2e)", () => {
         // Note: this should be 404
         it("should return 400 when ideation id does not exist", async () => {
             await request(app.getHttpServer())
-                .delete(
-                    `/voyages/teams/${userVoyageTeamId}/ideations/100/ideation-votes`,
-                )
+                .delete(`/voyages/ideations/100/ideation-votes`)
                 .set("Cookie", accessToken)
                 .expect(400);
         });

--- a/test/ideations.e2e-spec.ts
+++ b/test/ideations.e2e-spec.ts
@@ -335,9 +335,9 @@ describe("IdeationsController (e2e)", () => {
         });
     });
 
-    describe("/DELETE /teams/:teamId/ideations/:ideationId", () => {
+    describe("/DELETE /ideations/:ideationId", () => {
         const ideationId = 1;
-        const deleteIdeationUrl = `/voyages/teams/${userVoyageTeamId}/ideations/${ideationId}`;
+        const deleteIdeationUrl = `/voyages/ideations/${ideationId}`;
 
         // user can only delete their own ideation when there is no votes except their own,
         // this will also delete their own vote if exist
@@ -347,7 +347,7 @@ describe("IdeationsController (e2e)", () => {
                 await prisma.projectIdeaVote.count();
 
             await request(app.getHttpServer())
-                .delete(`/voyages/teams/${userVoyageTeamId}/ideations/3`)
+                .delete(`/voyages/ideations/3`)
                 .set("Cookie", accessToken)
                 .expect(200);
 
@@ -359,14 +359,14 @@ describe("IdeationsController (e2e)", () => {
         });
 
         // user cannot delete someone else's ideation
-        // Note: should be 403
+        // Add a 403 test
         it("should return 400 if the user delete their own ideation with other votes", async () => {
             const ideationCountBefore = await prisma.projectIdea.count();
             const ideationVoteCountBefore =
                 await prisma.projectIdeaVote.count();
 
             await request(app.getHttpServer())
-                .delete(`/voyages/teams/${userVoyageTeamId}/ideations/7`)
+                .delete(`/voyages/ideations/7`)
                 .set("Cookie", accessToken)
                 .expect(400);
 
@@ -386,7 +386,7 @@ describe("IdeationsController (e2e)", () => {
         // Should be 404
         it("should return 400 if ideation Id does not exist", async () => {
             await request(app.getHttpServer())
-                .delete(`/voyages/teams/${userVoyageTeamId}/ideations/200`)
+                .delete(`/voyages/ideations/200`)
                 .set("Cookie", accessToken)
                 .expect(400);
         });
@@ -410,7 +410,7 @@ describe("IdeationsController (e2e)", () => {
                 await prisma.projectIdeaVote.count();
 
             await request(app.getHttpServer())
-                .delete(`/voyages/teams/${userVoyageTeamId}/ideations/2`)
+                .delete(`/voyages/ideations/2`)
                 .set("Cookie", accessToken)
                 .expect(409);
 


### PR DESCRIPTION
# Description

Remove teamId params from 
`PATCH /voyages/ideations/{ideationId}`
`DELETE /voyages/ideations/{ideationId}`
`PATCH /voyages/ideations/{ideationId}/ideation-votes`
`DELETE /voyages/ideations/{ideationId}/ideation-votes`

## Issue link

https://app.clickup.com/t/86b0ump7x

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Tested manually on swagger and ran `yarn test:docker`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
