### PR TITLE
Bug: add check for team id in place of memberId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Another example [here](https://co-pilot.dev/changelog)
 - revised 2 checkin questions for alpha test ([#192](https://github.com/chingu-x/chingu-dashboard-be/pull/192))
 - updated changelog ([#195](https://github.com/chingu-x/chingu-dashboard-be/pull/195))
 - Fix seed checkin form data for PO and SM , and voyage-role for team 6 ([#196](https://github.com/chingu-x/chingu-dashboard-be/pull/196))
+- Bug add check for team id in place memberId ([#197](https://github.com/chingu-x/chingu-dashboard-be/pull/197))
 
 ### Removed
 

--- a/src/features/features.service.ts
+++ b/src/features/features.service.ts
@@ -244,7 +244,7 @@ export class FeaturesService {
             //check if the user is part of the team that owns the feature
             if (
                 !req.user.voyageTeams.some(
-                    (vt) => vt.memberId === currFeature.teamMemberId,
+                    (vt) => vt.teamId == currFeature.addedBy?.voyageTeamId,
                 )
             ) {
                 throw new ForbiddenException(
@@ -252,9 +252,7 @@ export class FeaturesService {
                 );
             }
 
-            const teamId = req.user.voyageTeams.find(
-                (vt) => vt.memberId == currFeature.teamMemberId,
-            )!.teamId!;
+            const teamId = currFeature.addedBy!.voyageTeamId!;
 
             const verifyCategoryExists =
                 await this.prisma.featureCategory.findFirst({
@@ -437,6 +435,13 @@ export class FeaturesService {
     private async findFeature(featureId: number) {
         const feature = await this.prisma.projectFeature.findUnique({
             where: { id: featureId },
+            include: {
+                addedBy: {
+                    select: {
+                        voyageTeamId: true,
+                    },
+                },
+            },
         });
 
         if (!feature) {

--- a/src/features/features.service.ts
+++ b/src/features/features.service.ts
@@ -244,7 +244,7 @@ export class FeaturesService {
             //check if the user is part of the team that owns the feature
             if (
                 !req.user.voyageTeams.some(
-                    (vt) => vt.teamId == currFeature.addedBy?.voyageTeamId,
+                    (vt) => vt.teamId === currFeature.addedBy?.voyageTeamId,
                 )
             ) {
                 throw new ForbiddenException(

--- a/test/features.e2e-spec.ts
+++ b/test/features.e2e-spec.ts
@@ -587,6 +587,23 @@ describe("Features Controller (e2e)", () => {
                     });
                 });
         });
+        it("should return 200 when a other user tries to update the order of features of same team", async () => {
+            const { access_token, refresh_token } = await loginAndGetTokens(
+                "leo.rowe@outlook.com",
+                "password",
+                app,
+            );
+            const featureId: number = 2;
+            const featureCategoryId: number = 2;
+            const order: number = 3;
+
+            await request(app.getHttpServer())
+                .patch(`/voyages/features/${featureId}/reorder`)
+                .send({ featureCategoryId, order })
+                .set("Cookie", [access_token, refresh_token])
+                .expect(200)
+                .expect("Content-Type", /json/);
+        });
         it("should return 400 for a invalid featureCategoryId", async () => {
             const { access_token, refresh_token } = await loginAndGetTokens(
                 "dan@random.com",


### PR DESCRIPTION
# Description

- Members of the same team can update the order and category of the features
- Removed the check for `memberId `  and replaced it with `teamId`
- Added a e2e test for the above change

## Issue link

[Fixes # (issue)](https://github.com/chingu-x/chingu-dashboard/issues/253)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

- tested with `yarn test:docker`
-  tested with `swagger`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
