### PR TITLE
Fix CORS origin localhost entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Another example [here](https://co-pilot.dev/changelog)
 ### Changed
 
 ### Fixed
+- Fix cors localhost address ([#205](https://github.com/chingu-x/chingu-dashboard-be/pull/205))
 
 ### Removed
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,9 +11,10 @@ import { AppConfigService } from "./config/app/appConfig.service";
 async function bootstrap() {
     const requestLogger = new Logger("Requests");
     const app = await NestFactory.create(AppModule);
+
     app.enableCors({
         origin: [
-            "http://localhost:*",
+            /^http:\/\/localhost:\d+$/,
             /^https:\/\/chingu-dashboard-[A-Za-z]+-chingu-dashboard\.vercel\.app$/,
             "https://chingu-dashboard-git-dev-chingu-dashboard.vercel.app",
             "https://chingu-dashboard.vercel.app",


### PR DESCRIPTION
# Description

Current CORS origin entry for localhost is wrong - `http://localhost:*` does not match all port, its just a static string, we need to use regex

## Issue link

-

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

tested on a dummy next.js client component (as CORS has no effect on server components)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
