### PR TITLE
refactor: changed E2E import paths to use '@/' 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Another example [here](https://co-pilot.dev/changelog)
 - Add units tests for the forms controller and services([#204](https://github.com/chingu-x/chingu-dashboard-be/pull/204))
 
 ### Changed
-
+- refactored e2e tests to use absolute import paths ([#207](https://github.com/chingu-x/chingu-dashboard-be/pull/207))
 ### Fixed
 
 ### Removed

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -10,11 +10,11 @@ import { RtStrategy } from "./strategies/rt.strategy";
 import { DiscordStrategy } from "./strategies/discord.strategy";
 import { DiscordAuthService } from "./discord-auth.service";
 import { EmailService } from "../utils/emails/email.service";
-import { MailConfigModule } from "src/config/mail/mailConfig.module";
-import { AppConfigModule } from "src/config/app/appConfig.module";
-import { AuthConfigModule } from "src/config/auth/authConfig.module";
+import { MailConfigModule } from "@/config/mail/mailConfig.module";
+import { AppConfigModule } from "@/config/app/appConfig.module";
+import { AuthConfigModule } from "@/config/auth/authConfig.module";
 import { OAuthConfigModule } from "../config/Oauth/oauthConfig.module";
-import { AuthConfig } from "src/config/auth/auth.interface";
+import { AuthConfig } from "@/config/auth/auth.interface";
 
 @Module({
     imports: [

--- a/src/development/development.module.ts
+++ b/src/development/development.module.ts
@@ -1,7 +1,7 @@
 import { Module } from "@nestjs/common";
 import { DevelopmentService } from "./development.service";
 import { DevelopmentController } from "./development.controller";
-import { AppConfigModule } from "src/config/app/appConfig.module";
+import { AppConfigModule } from "@/config/app/appConfig.module";
 
 @Module({
     imports: [AppConfigModule],

--- a/src/tasks/tasks.module.ts
+++ b/src/tasks/tasks.module.ts
@@ -1,6 +1,6 @@
 import { Module } from "@nestjs/common";
 import { TasksService } from "./tasks.service";
-import { PrismaModule } from "src/prisma/prisma.module";
+import { PrismaModule } from "@/prisma/prisma.module";
 
 @Module({
     providers: [TasksService],

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../src/app.module";
+import { AppModule } from "@/app.module";
 
 describe("AppController (e2e)", () => {
     let app: INestApplication;

--- a/test/development.e2e-spec.ts
+++ b/test/development.e2e-spec.ts
@@ -5,7 +5,7 @@ import * as cookieParser from "cookie-parser";
 import { loginAndGetTokens } from "./utils";
 import * as request from "supertest";
 import * as process from "node:process";
-import { AppConfigService } from "src/config/app/appConfig.service";
+import { AppConfigService } from "@/config/app/appConfig.service";
 
 describe("Development Controller (e2e)", () => {
     let app: INestApplication;

--- a/test/features.e2e-spec.ts
+++ b/test/features.e2e-spec.ts
@@ -1,12 +1,12 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../src/app.module";
-import { PrismaService } from "../src/prisma/prisma.service";
+import { AppModule } from "@/app.module";
+import { PrismaService } from "@/prisma/prisma.service";
 import { seed } from "../prisma/seed/seed";
 import { loginAndGetTokens } from "./utils";
 import * as cookieParser from "cookie-parser";
-import { CASLForbiddenExceptionFilter } from "src/exception-filters/casl-forbidden-exception.filter";
+import { CASLForbiddenExceptionFilter } from "@/exception-filters/casl-forbidden-exception.filter";
 
 // Logged in user is dan@random.com
 // Dan is a member of teamId 1 and teamMemberId 1

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,11 +1,14 @@
 {
-  "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
-  "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
-  "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
-  },
-  "testTimeout": 70000,
-  "moduleDirectories": ["<rootDir>/../", "node_modules"]
+    "moduleFileExtensions": ["js", "json", "ts"],
+    "rootDir": "..",
+    "testEnvironment": "node",
+    "testRegex": ".e2e-spec.ts$",
+    "transform": {
+        "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "testTimeout": 70000,
+    "moduleDirectories": ["<rootDir>/../", "node_modules"],
+    "moduleNameMapper": {
+        "^@/(.*)$": "<rootDir>/src/$1"
+    }
 }

--- a/test/teams.e2e-spec.ts
+++ b/test/teams.e2e-spec.ts
@@ -1,12 +1,12 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../src/app.module";
-import { PrismaService } from "../src/prisma/prisma.service";
+import { AppModule } from "@/app.module";
+import { PrismaService } from "@/prisma/prisma.service";
 import { seed } from "../prisma/seed/seed";
 import { loginAndGetTokens } from "./utils";
 import * as cookieParser from "cookie-parser";
-import { CASLForbiddenExceptionFilter } from "src/exception-filters/casl-forbidden-exception.filter";
+import { CASLForbiddenExceptionFilter } from "@/exception-filters/casl-forbidden-exception.filter";
 
 //Logged in user is Jessica Williamson for admin routes /teams and /teams/voyages/:voyageid
 //Logged in user is Dan ko for team member routes /teams/:teamid and /teams/:teamid/members

--- a/test/unverifiedUser.e2e-spec.ts
+++ b/test/unverifiedUser.e2e-spec.ts
@@ -1,12 +1,12 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../src/app.module";
-import { PrismaService } from "../src/prisma/prisma.service";
+import { AppModule } from "@/app.module";
+import { PrismaService } from "@/prisma/prisma.service";
 import { seed } from "../prisma/seed/seed";
 import { loginAndGetTokens } from "./utils";
 import * as cookieParser from "cookie-parser";
-import { CASLForbiddenExceptionFilter } from "src/exception-filters/casl-forbidden-exception.filter";
+import { CASLForbiddenExceptionFilter } from "@/exception-filters/casl-forbidden-exception.filter";
 
 //Logged in user is Yoshi Amano
 //Tests are for routes that are accessible to unverified users

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -1,12 +1,12 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../src/app.module";
-import { PrismaService } from "../src/prisma/prisma.service";
+import { AppModule } from "@/app.module";
+import { PrismaService } from "@/prisma/prisma.service";
 import { seed } from "../prisma/seed/seed";
 import { getUseridFromEmail, loginAndGetTokens } from "./utils";
 import * as cookieParser from "cookie-parser";
-import { CASLForbiddenExceptionFilter } from "src/exception-filters/casl-forbidden-exception.filter";
+import { CASLForbiddenExceptionFilter } from "@/exception-filters/casl-forbidden-exception.filter";
 
 //Logged in user is Jessica Williamson for admin routes
 //Logged in user is Dan ko for non admin routes


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
The import paths are changed to use the alias '@/' instead of relative paths. This improves code readability and maintainability by making it easier to understand the structure of the project and reducing the complexity of navigating through nested directories.

## Issue link

Fixes [Make e2e imports (and other imports) work with paths/absolute inputs](https://app.clickup.com/t/86b2346xp)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature updates / changes
- [ ] Tests
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

You test this PR by running the command `yarn test:e2e` or `yarn test:e2e:docker`, which all tests should pass.

If we want I could work adding absolute paths to the unit tests too. Let me know in the comments.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the change log
