### PR TITLE
Fix/voyage sprints get teamid 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ Another example [here](https://co-pilot.dev/changelog)
 ## [Unreleased]
 
 ### Added
-- Add units tests for the forms controller and services([#209](https://github.com/chingu-x/chingu-dashboard-be/pull/209))
+- Add units tests for the forms controller and services([#204](https://github.com/chingu-x/chingu-dashboard-be/pull/204))
 
 ### Changed
 
 ### Fixed
-- Fix voyages/sprints/teams/{teamId} returning wrong meetingIds ([#203](https://github.com/chingu-x/chingu-dashboard-be/pull/203))
+- Fix voyages/sprints/teams/{teamId} returning wrong meetingIds ([#209](https://github.com/chingu-x/chingu-dashboard-be/pull/209))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ Another example [here](https://co-pilot.dev/changelog)
 ## [Unreleased]
 
 ### Added
-- Add units tests for the forms controller and services([#204](https://github.com/chingu-x/chingu-dashboard-be/pull/204))
+- Add units tests for the forms controller and services([#209](https://github.com/chingu-x/chingu-dashboard-be/pull/209))
 
 ### Changed
 
 ### Fixed
+- Fix voyages/sprints/teams/{teamId} returning wrong meetingIds ([#203](https://github.com/chingu-x/chingu-dashboard-be/pull/203))
 
 ### Removed
 

--- a/src/sprints/sprints.controller.ts
+++ b/src/sprints/sprints.controller.ts
@@ -122,6 +122,7 @@ export class SprintsController {
     ) {
         return this.sprintsService.getSprintDatesByTeamId(teamId, req);
     }
+
     @ApiOperation({
         summary: "[Permissions: Own Team] gets meeting detail given meeting ID",
         description:


### PR DESCRIPTION
# Description

GET Voyage/Sprints/Teams/{TeamId} was pulling all TeamMeetings for the voyage the team is in, instead of team specific teamMeeting Ids.

Return structure was kept the same so minimal change is required.

This may or may not fix https://github.com/chingu-x/chingu-dashboard/issues/264

## Issue link

No task on clickup, as it just came up and fixed it while investigating
More detail here - https://docs.google.com/document/d/1K-xjyYnOAEUROHDXCARpX7okleW3S5BYf05f7Sb0k_E/edit?usp=sharing

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

checked manually on swagger and ran the tests


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
