### PR TITLE
Update docker compose to use timescaledb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Another example [here](https://co-pilot.dev/changelog)
 - Add units tests for the forms controller and services([#204](https://github.com/chingu-x/chingu-dashboard-be/pull/204))
 
 ### Changed
+- Update PostgreSQL image to timescale/timescaledb-ha:pg16 to match railway postgres image ([#210](https://github.com/chingu-x/chingu-dashboard-be/pull/210))
 
 ### Fixed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   postgres:
     container_name: postgres
-    image: postgres:15-alpine
+    image: timescale/timescaledb-ha:pg16
     restart: always
     ports:
       - "5433:5433"
@@ -15,7 +15,7 @@ services:
 
   postgres-test:
     container_name: postgres-test
-    image: postgres:15-alpine
+    image: timescale/timescaledb-ha:pg16
     restart: always
     environment:
       - POSTGRES_USER=chingu


### PR DESCRIPTION
# Description

Update docker compose to use Timescaledb/pg16 - which allows backup/restore between deployed db on railway 

## Issue link

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

`yarn docker --build`, `yarn push`, `yarn seed` everything ran fine, checked on swagger as well


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
