### PR TITLE
add same site property to cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Another example [here](https://co-pilot.dev/changelog)
 
 ### Added
 - Add units tests for the forms controller and services([#204](https://github.com/chingu-x/chingu-dashboard-be/pull/204))
+- Add same site property to cookie ([#212](https://github.com/chingu-x/chingu-dashboard-be/pull/212))
 
 ### Changed
 - refactored e2e tests to use absolute import paths ([#207](https://github.com/chingu-x/chingu-dashboard-be/pull/207))

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -134,11 +134,13 @@ export class AuthService {
             maxAge: AT_MAX_AGE * 1000,
             httpOnly: true,
             secure: true,
+            sameSite: "none",
         });
         res.cookie("refresh_token", refresh_token, {
             maxAge: RT_MAX_AGE * 1000,
             httpOnly: true,
             secure: true,
+            sameSite: "none",
         });
     }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -134,7 +134,7 @@ export class AuthService {
             maxAge: AT_MAX_AGE * 1000,
             httpOnly: true,
             secure: true,
-            sameSite: "none",
+            sameSite: "none", // TODO: remove this in future when we use actual domains for the dashboard, they will likely be same-site
         });
         res.cookie("refresh_token", refresh_token, {
             maxAge: RT_MAX_AGE * 1000,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -134,7 +134,7 @@ export class AuthService {
             maxAge: AT_MAX_AGE * 1000,
             httpOnly: true,
             secure: true,
-            sameSite: "none", // TODO: remove this in future when we use actual domains for the dashboard, they will likely be same-site
+            sameSite: "none",
         });
         res.cookie("refresh_token", refresh_token, {
             maxAge: RT_MAX_AGE * 1000,


### PR DESCRIPTION
# Description

I'm having trouble getting a screenshot for this but basically there is an issue with the cookies and cross-site domains so we need to set the same-site as none. Adding that fixed this issue

This is probably only an issue with client components but since we are gunna have a separate react project in the future (which would be client) that'll communicate with this backend, this would fix for that usecase as well

## Issue link

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

I ran into this issue when trying to test from localhost on frontend and the deployed backend dev server.
I also ran into this issue using localhost on the backend and the preview deployed url on vercel (it's using the localhost backend, just different domain).

After implementing this, it worked as expected


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
