### PR TITLE
add same site property to the cookie sent in the refresh endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Another example [here](https://co-pilot.dev/changelog)
 
 - Add units tests for the forms controller and services([#204](https://github.com/chingu-x/chingu-dashboard-be/pull/204))
 - Add same site property to cookie ([#212](https://github.com/chingu-x/chingu-dashboard-be/pull/212))
+- Add same site property to cookie in refresh endpoint ([#214](https://github.com/chingu-x/chingu-dashboard-be/pull/214))
 
 ### Changed
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -37,7 +37,6 @@ import { JwtAuthGuard } from "./guards/jwt-auth.guard";
 import { JwtRefreshAuthGuard } from "./guards/jwt-rt-auth.guard";
 import { Public } from "../global/decorators/public.decorator";
 import { Unverified } from "../global/decorators/unverified.decorator";
-import { AT_MAX_AGE, RT_MAX_AGE } from "../global/constants";
 import { RevokeRTDto } from "./dto/revoke-refresh-token.dto";
 import { CheckAbilities } from "../global/decorators/abilities.decorator";
 import { Action } from "../ability/ability.factory/ability.factory";
@@ -198,18 +197,7 @@ export class AuthController {
             req.user,
         );
 
-        res.cookie("access_token", access_token, {
-            maxAge: AT_MAX_AGE * 1000,
-            httpOnly: true,
-            secure: true,
-            sameSite: "none",
-        });
-        res.cookie("refresh_token", refresh_token, {
-            maxAge: RT_MAX_AGE * 1000,
-            httpOnly: true,
-            secure: true,
-            sameSite: "none",
-        });
+        this.authService.setCookie(res, access_token, refresh_token);
         res.status(HttpStatus.OK).send({ message: "Refresh Success" });
     }
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -202,11 +202,13 @@ export class AuthController {
             maxAge: AT_MAX_AGE * 1000,
             httpOnly: true,
             secure: true,
+            sameSite: "none",
         });
         res.cookie("refresh_token", refresh_token, {
             maxAge: RT_MAX_AGE * 1000,
             httpOnly: true,
             secure: true,
+            sameSite: "none",
         });
         res.status(HttpStatus.OK).send({ message: "Refresh Success" });
     }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -125,11 +125,7 @@ export class AuthService {
         }
     };
 
-    async returnTokensOnLoginSuccess(req: CustomRequest, res: Response) {
-        const { access_token, refresh_token } = await this.login(
-            req.user,
-            req.cookies?.refresh_token,
-        );
+    setCookie(res: Response, access_token: string, refresh_token: string) {
         res.cookie("access_token", access_token, {
             maxAge: AT_MAX_AGE * 1000,
             httpOnly: true,
@@ -142,6 +138,14 @@ export class AuthService {
             secure: true,
             sameSite: "none",
         });
+    }
+
+    async returnTokensOnLoginSuccess(req: CustomRequest, res: Response) {
+        const { access_token, refresh_token } = await this.login(
+            req.user,
+            req.cookies?.refresh_token,
+        );
+        this.setCookie(res, access_token, refresh_token);
     }
 
     /**


### PR DESCRIPTION
# Description

I have no idea why I didn't run into this issue before. Gotta love dev work sometimes. 

![screenshot](https://i.imgur.com/atIjKLx.png)
![screenshot](https://i.imgur.com/hSxw6gy.png)

The refresh endpoint needs to have the same site property added as well and I fixed that in this pr. 

Could maybe look into refactoring it but I'll leave that to BE team.

Also, I'm not sure if it was intentional to add a new refresh token cookie too in the refresh endpoint?

## Issue link

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature updates / changes
- [ ] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

I tested with localhost on backend and a deployed url in vercel. I did this in last pr too but for whatever reason this issue didn't come up last time. But it is working again with this fix.

https://chingu-dashboard-git-feature-refreshtoken-chingu-dashboard.vercel.app/dashboard


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
