### PR TITLE
Update tech selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Changed
 - Updated cors origin list ([#218](https://github.com/chingu-x/chingu-dashboard-be/pull/218))
 - refactored unit tests for the ideations controller and services([#219](https://github.com/chingu-x/chingu-dashboard-be/pull/219))
+- revised tech selections route to update only one tech per request([#221](https://github.com/chingu-x/chingu-dashboard-be/pull/221))
 ### Fixed
 
 ### Removed

--- a/src/techs/dto/update-tech-selections.dto.ts
+++ b/src/techs/dto/update-tech-selections.dto.ts
@@ -1,24 +1,15 @@
 import { ApiProperty } from "@nestjs/swagger";
 
-export class TechSelectionDto {
-    @ApiProperty({
-        description: "tech id",
-        example: 1,
-    })
-    techId: number;
+export class UpdateTechSelectionDto {
+    // @ApiProperty({
+    //     description: "tech id",
+    //     example: 1,
+    // })
+    // techId: number;
 
     @ApiProperty({
         description: "Selected flag",
         example: true,
     })
     isSelected: boolean;
-}
-
-export class UpdateTechSelectionsDto {
-    @ApiProperty({
-        description: "Array of tech items to update 'isSelected'.",
-        type: TechSelectionDto,
-        isArray: true,
-    })
-    techs: TechSelectionDto[];
 }

--- a/src/techs/dto/update-tech-selections.dto.ts
+++ b/src/techs/dto/update-tech-selections.dto.ts
@@ -16,7 +16,7 @@ export class TechSelectionDto {
 
 export class TechCategoryDto {
     @ApiProperty({
-        description: "tech id",
+        description: "category id",
         example: 1,
     })
     categoryId: number;
@@ -29,11 +29,11 @@ export class TechCategoryDto {
     techs: TechSelectionDto[];
 }
 
-export class UpdateTechSelectionsDto {
-    @ApiProperty({
-        description: "Array of categories with tech selection values",
-        type: TechCategoryDto,
-        isArray: true,
-    })
-    categories: TechCategoryDto[];
-}
+// export class UpdateTechSelectionsDto {
+//     @ApiProperty({
+//         description: "Array of categories with tech selection values",
+//         type: TechCategoryDto,
+//         isArray: true,
+//     })
+//     categories: TechCategoryDto[];
+// }

--- a/src/techs/dto/update-tech-selections.dto.ts
+++ b/src/techs/dto/update-tech-selections.dto.ts
@@ -14,13 +14,7 @@ export class TechSelectionDto {
     isSelected: boolean;
 }
 
-export class TechCategoryDto {
-    @ApiProperty({
-        description: "category id",
-        example: 1,
-    })
-    categoryId: number;
-
+export class UpdateTechSelectionsDto {
     @ApiProperty({
         description: "Array of tech items to update 'isSelected'.",
         type: TechSelectionDto,
@@ -28,12 +22,3 @@ export class TechCategoryDto {
     })
     techs: TechSelectionDto[];
 }
-
-// export class UpdateTechSelectionsDto {
-//     @ApiProperty({
-//         description: "Array of categories with tech selection values",
-//         type: TechCategoryDto,
-//         isArray: true,
-//     })
-//     categories: TechCategoryDto[];
-// }

--- a/src/techs/dto/update-tech-selections.dto.ts
+++ b/src/techs/dto/update-tech-selections.dto.ts
@@ -1,12 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
 
 export class UpdateTechSelectionDto {
-    // @ApiProperty({
-    //     description: "tech id",
-    //     example: 1,
-    // })
-    // techId: number;
-
     @ApiProperty({
         description: "Selected flag",
         example: true,

--- a/src/techs/techs.controller.ts
+++ b/src/techs/techs.controller.ts
@@ -477,16 +477,16 @@ export class TechsController {
         type: ForbiddenErrorResponse,
     })
     @CheckAbilities({ action: Action.Update, subject: "TeamTechStackItem" })
-    @Patch("teams/techs/:techId")
+    @Patch("techs/:techId/selection")
     updateTechStackSelections(
         @Request() req,
         @Param("techId", ParseIntPipe) techId: number,
-        @Body(ValidationPipe) techSelectionDto: UpdateTechSelectionDto,
+        @Body(ValidationPipe) upateTechSelectionDto: UpdateTechSelectionDto,
     ) {
         return this.techsService.updateTechStackSelections(
             req,
             techId,
-            techSelectionDto,
+            upateTechSelectionDto,
         );
     }
 }

--- a/src/techs/techs.controller.ts
+++ b/src/techs/techs.controller.ts
@@ -476,13 +476,6 @@ export class TechsController {
         description: "forbidden - user does not have the required permission",
         type: ForbiddenErrorResponse,
     })
-    @ApiParam({
-        name: "teamId",
-        description: "voyage team Id",
-        type: "Integer",
-        required: true,
-        example: 2,
-    })
     @CheckAbilities({ action: Action.Update, subject: "TeamTechStackItem" })
     @Patch("teams/techs/:techId")
     updateTechStackSelections(

--- a/src/techs/techs.controller.ts
+++ b/src/techs/techs.controller.ts
@@ -14,7 +14,7 @@ import {
 import { TechsService } from "./techs.service";
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { CreateTeamTechDto } from "./dto/create-tech.dto";
-import { TechCategoryDto } from "./dto/update-tech-selections.dto";
+import { UpdateTechSelectionsDto } from "./dto/update-tech-selections.dto";
 import { CreateTechStackCategoryDto } from "./dto/create-techstack-category.dto";
 import { UpdateTechStackCategoryDto } from "./dto/update-techstack-category.dto";
 import {
@@ -453,9 +453,9 @@ export class TechsController {
 
     @ApiOperation({
         summary:
-            "[Permission: own_team]  Updates arrays of tech stack items, grouped by categoryId, sets 'isSelected' values",
+            "[Permission: own_team]  Updates an array of tech stack items of same category, sets 'isSelected' values",
         description:
-            "Maximum of 3 selections per category allowed.  All tech items (isSelected === true/false) are required for updated categories. Login required.",
+            "Maximum of 3 selections per category allowed.  All tech items must be in same category.  All tech items (isSelected === true/false) are required for updated category. Login required.",
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -489,7 +489,7 @@ export class TechsController {
     updateTechStackSelections(
         @Request() req,
         @Param("teamId", ParseIntPipe) teamId: number,
-        @Body(ValidationPipe) updateTechSelectionsDto: TechCategoryDto,
+        @Body(ValidationPipe) updateTechSelectionsDto: UpdateTechSelectionsDto,
     ) {
         return this.techsService.updateTechStackSelections(
             req,

--- a/src/techs/techs.controller.ts
+++ b/src/techs/techs.controller.ts
@@ -14,7 +14,7 @@ import {
 import { TechsService } from "./techs.service";
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { CreateTeamTechDto } from "./dto/create-tech.dto";
-import { UpdateTechSelectionsDto } from "./dto/update-tech-selections.dto";
+import { TechCategoryDto } from "./dto/update-tech-selections.dto";
 import { CreateTechStackCategoryDto } from "./dto/create-techstack-category.dto";
 import { UpdateTechStackCategoryDto } from "./dto/update-techstack-category.dto";
 import {
@@ -489,7 +489,7 @@ export class TechsController {
     updateTechStackSelections(
         @Request() req,
         @Param("teamId", ParseIntPipe) teamId: number,
-        @Body(ValidationPipe) updateTechSelectionsDto: UpdateTechSelectionsDto,
+        @Body(ValidationPipe) updateTechSelectionsDto: TechCategoryDto,
     ) {
         return this.techsService.updateTechStackSelections(
             req,

--- a/src/techs/techs.controller.ts
+++ b/src/techs/techs.controller.ts
@@ -14,7 +14,7 @@ import {
 import { TechsService } from "./techs.service";
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { CreateTeamTechDto } from "./dto/create-tech.dto";
-import { UpdateTechSelectionsDto } from "./dto/update-tech-selections.dto";
+import { UpdateTechSelectionDto } from "./dto/update-tech-selections.dto";
 import { CreateTechStackCategoryDto } from "./dto/create-techstack-category.dto";
 import { UpdateTechStackCategoryDto } from "./dto/update-techstack-category.dto";
 import {
@@ -453,13 +453,12 @@ export class TechsController {
 
     @ApiOperation({
         summary:
-            "[Permission: own_team]  Updates an array of tech stack items of same category, sets 'isSelected' values",
-        description:
-            "Maximum of 3 selections per category allowed.  All tech items must be in same category.  All tech items (isSelected === true/false) are required for updated category. Login required.",
+            "[Permission: own_team]  Updates a tech stack item selection, sets 'isSelected' value",
+        description: "Login required.",
     })
     @ApiResponse({
         status: HttpStatus.OK,
-        description: "Successfully updated selected tech stack items",
+        description: "Successfully updated selected tech stack item",
         type: TechItemResponse,
     })
     @ApiResponse({
@@ -485,16 +484,16 @@ export class TechsController {
         example: 2,
     })
     @CheckAbilities({ action: Action.Update, subject: "TeamTechStackItem" })
-    @Patch("teams/:teamId/techs/selections")
+    @Patch("teams/techs/:techId")
     updateTechStackSelections(
         @Request() req,
-        @Param("teamId", ParseIntPipe) teamId: number,
-        @Body(ValidationPipe) updateTechSelectionsDto: UpdateTechSelectionsDto,
+        @Param("techId", ParseIntPipe) techId: number,
+        @Body(ValidationPipe) techSelectionDto: UpdateTechSelectionDto,
     ) {
         return this.techsService.updateTechStackSelections(
             req,
-            teamId,
-            updateTechSelectionsDto,
+            techId,
+            techSelectionDto,
         );
     }
 }

--- a/src/techs/techs.service.ts
+++ b/src/techs/techs.service.ts
@@ -10,7 +10,7 @@ import { PrismaService } from "../prisma/prisma.service";
 import { CreateTeamTechDto } from "./dto/create-tech.dto";
 import { CreateTechStackCategoryDto } from "./dto/create-techstack-category.dto";
 import { UpdateTechStackCategoryDto } from "./dto/update-techstack-category.dto";
-import { UpdateTechSelectionsDto } from "./dto/update-tech-selections.dto";
+import { UpdateTechSelectionDto } from "./dto/update-tech-selections.dto";
 import { UpdateTeamTechDto } from "./dto/update-tech.dto";
 import { CustomRequest, VoyageTeam } from "../global/types/CustomRequest";
 import { manageOwnVoyageTeamWithIdParam } from "@/ability/conditions/voyage-teams.ability";
@@ -74,37 +74,33 @@ export class TechsService {
 
     async updateTechStackSelections(
         req: CustomRequest,
-        teamId: number,
-        updateTechSelectionsDto: UpdateTechSelectionsDto,
+        techId: number,
+        updateTechSelectionsDto: UpdateTechSelectionDto,
     ) {
         //check for valid teamId
-        await this.validateTeamId(teamId);
+        //await this.validateTeamId(teamId);
 
         //check if user is a member of the team
-        manageOwnVoyageTeamWithIdParam(req.user, teamId);
+        //manageOwnVoyageTeamWithIdParam(req.user, teamId);
 
-        const techs = updateTechSelectionsDto.techs;
-        const selectCount = techs.reduce(
-            (acc: number, tech) => acc + (tech.isSelected ? 1 : 0),
-            0,
-        );
-        if (selectCount > MAX_SELECTION_COUNT)
-            throw new BadRequestException(
-                `Only ${MAX_SELECTION_COUNT} selections allowed per category`,
-            );
+        //TODO: check if more than max selections
+        // const selectCount = techs.reduce(
+        //     (acc: number, tech) => acc + (tech.isSelected ? 1 : 0),
+        //     0,
+        // );
+        // if (selectCount > MAX_SELECTION_COUNT)
+        //     throw new BadRequestException(
+        //         `Only ${MAX_SELECTION_COUNT} selections allowed per category`,
+        //     );
 
-        return this.prisma.$transaction(
-            techs.map((tech) => {
-                return this.prisma.teamTechStackItem.update({
-                    where: {
-                        id: tech.techId,
-                    },
-                    data: {
-                        isSelected: tech.isSelected,
-                    },
-                });
-            }),
-        );
+        return this.prisma.teamTechStackItem.update({
+            where: {
+                id: techId,
+            },
+            data: {
+                isSelected: updateTechSelectionsDto.isSelected,
+            },
+        });
     }
 
     async addNewTeamTech(

--- a/src/techs/techs.service.ts
+++ b/src/techs/techs.service.ts
@@ -10,7 +10,7 @@ import { PrismaService } from "../prisma/prisma.service";
 import { CreateTeamTechDto } from "./dto/create-tech.dto";
 import { CreateTechStackCategoryDto } from "./dto/create-techstack-category.dto";
 import { UpdateTechStackCategoryDto } from "./dto/update-techstack-category.dto";
-import { UpdateTechSelectionsDto } from "./dto/update-tech-selections.dto";
+import { TechCategoryDto } from "./dto/update-tech-selections.dto";
 import { UpdateTeamTechDto } from "./dto/update-tech.dto";
 import { CustomRequest, VoyageTeam } from "../global/types/CustomRequest";
 import { manageOwnVoyageTeamWithIdParam } from "@/ability/conditions/voyage-teams.ability";
@@ -75,7 +75,7 @@ export class TechsService {
     async updateTechStackSelections(
         req: CustomRequest,
         teamId: number,
-        updateTechSelectionsDto: UpdateTechSelectionsDto,
+        updateTechSelectionsDto: TechCategoryDto,
     ) {
         //check for valid teamId
         await this.validateTeamId(teamId);
@@ -83,27 +83,37 @@ export class TechsService {
         //check if user is a member of the team
         manageOwnVoyageTeamWithIdParam(req.user, teamId);
 
-        const categories = updateTechSelectionsDto.categories;
+        const techs = updateTechSelectionsDto.techs;
 
         //count selections in categories for exceeding MAX_SELECT_COUNT
-        categories.forEach((category) => {
-            const selectCount = category.techs.reduce(
-                (acc: number, tech) => acc + (tech.isSelected ? 1 : 0),
-                0,
+        // categories.forEach((category) => {
+        //     const selectCount = category.techs.reduce(
+        //         (acc: number, tech) => acc + (tech.isSelected ? 1 : 0),
+        //         0,
+        //     );
+        //     if (selectCount > MAX_SELECTION_COUNT)
+        //         throw new BadRequestException(
+        //             `Only ${MAX_SELECTION_COUNT} selections allowed per category`,
+        //         );
+        // });
+        const selectCount = techs.reduce(
+            (acc: number, tech) => acc + (tech.isSelected ? 1 : 0),
+            0,
+        );
+        if (selectCount > MAX_SELECTION_COUNT)
+            throw new BadRequestException(
+                `Only ${MAX_SELECTION_COUNT} selections allowed per category`,
             );
-            if (selectCount > MAX_SELECTION_COUNT)
-                throw new BadRequestException(
-                    `Only ${MAX_SELECTION_COUNT} selections allowed per category`,
-                );
-        });
 
         //extract techs to an array for .map
-        const techsArray: any[] = [];
-        categories.forEach((category) => {
-            category.techs.forEach((tech) => techsArray.push(tech));
-        });
+        //const techsArray: any[] = [];
+        // categories.forEach((category) => {
+        //     category.techs.forEach((tech) => techsArray.push(tech));
+        // });
+        //techs.forEach((tech) => techsArray.push(tech)); //todo: skip this - not needed
+
         return this.prisma.$transaction(
-            techsArray.map((tech) => {
+            techs.map((tech) => {
                 return this.prisma.teamTechStackItem.update({
                     where: {
                         id: tech.techId,

--- a/test/techs.e2e-spec.ts
+++ b/test/techs.e2e-spec.ts
@@ -196,7 +196,7 @@ describe("Techs Controller (e2e)", () => {
 
             return request(app.getHttpServer())
                 .post(`/voyages/teams/${teamId}/techs`)
-                .set("Authorization", `Bearer ${undefined}`)
+                .set("Cookie", "undefined")
                 .send({
                     techName: newTechName,
                     techCategoryId: 1,
@@ -226,8 +226,8 @@ describe("Techs Controller (e2e)", () => {
                 .post(`/voyages/teams/${teamId}/techs`)
                 .set("Cookie", access_token)
                 .send({
-                    techName: newTechName,
-                    techCategoryId: 1,
+                    techName: newTechName + "678",
+                    techCategoryId: 7,
                     voyageTeamMemberId: teamMemberId,
                 })
                 .expect(403);
@@ -677,12 +677,12 @@ describe("Techs Controller (e2e)", () => {
         });
     });
 
-    describe("PATCH voyages/teams/:teamId/techs/selections - updates isSelected value of a tech stack tems", () => {
+    describe("PATCH voyages/techs/selections - updates isSelected value of a tech stack items", () => {
         it("should return 200 and an updated tech, if successful", async () => {
             const techId: number = 1;
 
             return request(app.getHttpServer())
-                .patch(`/voyages/teams/techs/${techId}`)
+                .patch(`/voyages/techs/${techId}/selection`)
                 .set("Cookie", accessToken)
                 .send({
                     isSelected: true,
@@ -750,7 +750,7 @@ describe("Techs Controller (e2e)", () => {
             });
 
             return request(app.getHttpServer())
-                .patch(`/voyages/teams/techs/${techId}`)
+                .patch(`/voyages/techs/${techId}/selection`)
                 .set("Cookie", accessToken)
                 .send({
                     isSelected: true,
@@ -768,7 +768,7 @@ describe("Techs Controller (e2e)", () => {
             const techId: number = 1;
 
             return request(app.getHttpServer())
-                .patch(`/voyages/teams/techs/${techId}`)
+                .patch(`/voyages/techs/${techId}/selection`)
                 .set("Cookie", access_token)
                 .send({
                     isSelected: true,
@@ -780,8 +780,8 @@ describe("Techs Controller (e2e)", () => {
             const techId: number = 1;
 
             return request(app.getHttpServer())
-                .patch(`/voyages/teams/techs/${techId}`)
-                .set("Authorization", `Bearer ${undefined}`)
+                .patch(`/voyages/techs/${techId}/selection`)
+                .set("Cookie", "undefined")
                 .send({
                     isSelected: true,
                 })

--- a/test/techs.e2e-spec.ts
+++ b/test/techs.e2e-spec.ts
@@ -685,15 +685,10 @@ describe("Techs Controller (e2e)", () => {
                 .patch(`/voyages/teams/${teamId}/techs/selections`)
                 .set("Cookie", accessToken)
                 .send({
-                    categories: [
+                    techs: [
                         {
-                            categoryId: 1,
-                            techs: [
-                                {
-                                    techId: 1,
-                                    isSelected: true,
-                                },
-                            ],
+                            techId: 1,
+                            isSelected: true,
                         },
                     ],
                 })
@@ -719,27 +714,22 @@ describe("Techs Controller (e2e)", () => {
                 .patch(`/voyages/teams/${teamId}/techs/selections`)
                 .set("Cookie", accessToken)
                 .send({
-                    categories: [
+                    techs: [
                         {
-                            categoryId: 1,
-                            techs: [
-                                {
-                                    techId: 1,
-                                    isSelected: true,
-                                },
-                                {
-                                    techId: 2,
-                                    isSelected: true,
-                                },
-                                {
-                                    techId: 3,
-                                    isSelected: true,
-                                },
-                                {
-                                    techId: 4,
-                                    isSelected: true,
-                                },
-                            ],
+                            techId: 1,
+                            isSelected: true,
+                        },
+                        {
+                            techId: 2,
+                            isSelected: true,
+                        },
+                        {
+                            techId: 3,
+                            isSelected: true,
+                        },
+                        {
+                            techId: 4,
+                            isSelected: true,
                         },
                     ],
                 })
@@ -753,15 +743,10 @@ describe("Techs Controller (e2e)", () => {
                 .patch(`/voyages/teams/${teamId}/techs/selections`)
                 .set("Cookie", accessToken)
                 .send({
-                    categories: [
+                    techs: [
                         {
-                            categoryId: 1,
-                            techs: [
-                                {
-                                    techId: 1,
-                                    isSelected: true,
-                                },
-                            ],
+                            techId: 1,
+                            isSelected: true,
                         },
                     ],
                 })
@@ -780,15 +765,10 @@ describe("Techs Controller (e2e)", () => {
                 .patch(`/voyages/teams/${teamId}/techs/selections`)
                 .set("Cookie", access_token)
                 .send({
-                    categories: [
+                    techs: [
                         {
-                            categoryId: 1,
-                            techs: [
-                                {
-                                    techId: 1,
-                                    isSelected: true,
-                                },
-                            ],
+                            techId: 1,
+                            isSelected: true,
                         },
                     ],
                 })
@@ -802,15 +782,10 @@ describe("Techs Controller (e2e)", () => {
                 .patch(`/voyages/teams/${teamId}/techs/selections`)
                 .set("Authorization", `Bearer ${undefined}`)
                 .send({
-                    categories: [
+                    techs: [
                         {
-                            categoryId: 1,
-                            techs: [
-                                {
-                                    techId: 1,
-                                    isSelected: true,
-                                },
-                            ],
+                            techId: 1,
+                            isSelected: true,
                         },
                     ],
                 })

--- a/test/techs.e2e-spec.ts
+++ b/test/techs.e2e-spec.ts
@@ -677,81 +677,87 @@ describe("Techs Controller (e2e)", () => {
         });
     });
 
-    describe("PATCH voyages/teams/:teamId/techs/selections - updates isSelected value of tech stack items", () => {
-        it("should return 200 and an array of updated techs, if successful", async () => {
-            const teamId: number = 2;
+    describe("PATCH voyages/teams/:teamId/techs/selections - updates isSelected value of a tech stack tems", () => {
+        it("should return 200 and an updated tech, if successful", async () => {
+            const techId: number = 1;
 
             return request(app.getHttpServer())
-                .patch(`/voyages/teams/${teamId}/techs/selections`)
+                .patch(`/voyages/teams/techs/${techId}`)
                 .set("Cookie", accessToken)
                 .send({
-                    techs: [
-                        {
-                            techId: 1,
-                            isSelected: true,
-                        },
-                    ],
+                    isSelected: true,
                 })
                 .expect(200)
                 .expect("Content-Type", /json/)
                 .expect((res) => {
                     expect(res.body).toEqual(
-                        expect.arrayContaining([
-                            expect.objectContaining({
-                                categoryId: expect.any(Number),
-                                isSelected: expect.any(Boolean),
-                                name: expect.any(String),
-                            }),
-                        ]),
+                        expect.objectContaining({
+                            id: expect.any(Number),
+                            categoryId: expect.any(Number),
+                            isSelected: expect.any(Boolean),
+                            name: expect.any(String),
+                            voyageTeamId: expect.any(Number),
+                            voyageTeamMemberId: expect.any(Number),
+                            createdAt: expect.any(String),
+                            updatedAt: expect.any(String),
+                        }),
                     );
                 });
         });
 
         it("should return 400 if more than 3 selections in a category", async () => {
-            const teamId: number = 2;
+            const techId: number = 23;
+
+            //create 4 tech items , select 3
+            await prisma.teamTechStackItem.create({
+                data: {
+                    id: 20,
+                    name: "Test1",
+                    categoryId: 1,
+                    voyageTeamId: 1,
+                    isSelected: true,
+                },
+            });
+
+            await prisma.teamTechStackItem.create({
+                data: {
+                    id: 21,
+                    name: "Test2",
+                    categoryId: 1,
+                    voyageTeamId: 1,
+                    isSelected: true,
+                },
+            });
+
+            await prisma.teamTechStackItem.create({
+                data: {
+                    id: 22,
+                    name: "Test3",
+                    categoryId: 1,
+                    voyageTeamId: 1,
+                    isSelected: true,
+                },
+            });
+
+            await prisma.teamTechStackItem.create({
+                data: {
+                    id: 23,
+                    name: "Test4",
+                    categoryId: 1,
+                    voyageTeamId: 1,
+                    isSelected: false,
+                },
+            });
 
             return request(app.getHttpServer())
-                .patch(`/voyages/teams/${teamId}/techs/selections`)
+                .patch(`/voyages/teams/techs/${techId}`)
                 .set("Cookie", accessToken)
                 .send({
-                    techs: [
-                        {
-                            techId: 1,
-                            isSelected: true,
-                        },
-                        {
-                            techId: 2,
-                            isSelected: true,
-                        },
-                        {
-                            techId: 3,
-                            isSelected: true,
-                        },
-                        {
-                            techId: 4,
-                            isSelected: true,
-                        },
-                    ],
+                    isSelected: true,
                 })
                 .expect(400);
         });
 
-        it("should return 404 invalid team id provided", async () => {
-            const teamId: number = 999999;
-
-            return request(app.getHttpServer())
-                .patch(`/voyages/teams/${teamId}/techs/selections`)
-                .set("Cookie", accessToken)
-                .send({
-                    techs: [
-                        {
-                            techId: 1,
-                            isSelected: true,
-                        },
-                    ],
-                })
-                .expect(404);
-        });
         it("should return 403 if a user does not belong to the same team", async () => {
             const { access_token } = await loginAndGetTokens(
                 "dan@random.com",
@@ -759,35 +765,25 @@ describe("Techs Controller (e2e)", () => {
                 app,
             );
 
-            const teamId: number = 2;
+            const techId: number = 1;
 
             return request(app.getHttpServer())
-                .patch(`/voyages/teams/${teamId}/techs/selections`)
+                .patch(`/voyages/teams/techs/${techId}`)
                 .set("Cookie", access_token)
                 .send({
-                    techs: [
-                        {
-                            techId: 1,
-                            isSelected: true,
-                        },
-                    ],
+                    isSelected: true,
                 })
                 .expect(403);
         });
 
         it("should return 401 unauthorized if not logged in", async () => {
-            const teamId: number = 2;
+            const techId: number = 1;
 
             return request(app.getHttpServer())
-                .patch(`/voyages/teams/${teamId}/techs/selections`)
+                .patch(`/voyages/teams/techs/${techId}`)
                 .set("Authorization", `Bearer ${undefined}`)
                 .send({
-                    techs: [
-                        {
-                            techId: 1,
-                            isSelected: true,
-                        },
-                    ],
+                    isSelected: true,
                 })
                 .expect(401);
         });


### PR DESCRIPTION
# Description

- This PR revises the PATCH /teams/techs/:techId route to only update a single tech stack selection, setting the `isSelected` value
- Also, a permission bug has been fixed for POST /teams/{teamId}/techs , ensuring users can only add a new tech for thier own team


## Issue link

Fixes # [86b1ym631](https://app.clickup.com/t/86b1ym631)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Feature updates / changes
- [x] Tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

- migrate db for updates
- yarn test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the change log
