### PR TITLE
feat: Multiple Parse Options support Stage1b - Add parseConfig to forms response and service models

### DIFF
--- a/src/forms/forms.response.ts
+++ b/src/forms/forms.response.ts
@@ -125,12 +125,12 @@ class BaseQuestion {
 
     @Optional()
     @ApiProperty({
-        examples: {
+        description: "configuration for parsing the response",
+        example: {
             parseConfig: {
                 min: "Not Likely",
                 max: "Extremely Likely",
             },
-            description: "Configuration for scale questions",
         },
         required: false,
     })

--- a/src/forms/forms.response.ts
+++ b/src/forms/forms.response.ts
@@ -31,18 +31,8 @@ class OptionChoice {
     @ApiProperty({
         description: "configuration for parsing the response",
         example: {
-            example1: {
-                parseConfig: {
-                    icon: "greenRocket",
-                    iconUrl: ".../greenRocket.png",
-                },
-            },
-            example2: {
-                parseConfig: {
-                    yes: "Yes",
-                    no: "No",
-                },
-            },
+            icon: "greenRocket",
+            iconUrl: ".../greenRocket.png",
         },
         required: false,
     })
@@ -127,10 +117,8 @@ class BaseQuestion {
     @ApiProperty({
         description: "configuration for parsing the response",
         example: {
-            parseConfig: {
-                min: "Not Likely",
-                max: "Extremely Likely",
-            },
+            min: "Not Likely",
+            max: "Extremely Likely",
         },
         required: false,
     })

--- a/src/forms/forms.response.ts
+++ b/src/forms/forms.response.ts
@@ -26,6 +26,21 @@ class OptionChoice {
 
     @ApiProperty({ example: "Tier 1" })
     text: string;
+
+    @Optional()
+    @ApiProperty({
+        examples: {
+            iconConfig: {
+                value: {
+                    icon: "greenRocket",
+                    iconUrl: ".../greenRocket.png",
+                },
+                description: "Configuration for icon-based radio buttons",
+            },
+        },
+        required: false,
+    })
+    parseConfig?: Record<string, any>;
 }
 
 class OptionGroup {
@@ -101,6 +116,21 @@ class BaseQuestion {
     @Optional()
     @ApiProperty({ example: null })
     optionGroup: OptionGroup;
+
+    @Optional()
+    @ApiProperty({
+        examples: {
+            scaleConfig: {
+                value: {
+                    min: "Not Likely",
+                    max: "Extremely Likely",
+                },
+                description: "Configuration for scale questions",
+            },
+        },
+        required: false,
+    })
+    parseConfig?: Record<string, any>;
 
     @ApiProperty()
     createdAt: Date;

--- a/src/forms/forms.response.ts
+++ b/src/forms/forms.response.ts
@@ -29,12 +29,20 @@ class OptionChoice {
 
     @Optional()
     @ApiProperty({
-        examples: {
-            parseConfig: {
-                icon: "greenRocket",
-                iconUrl: ".../greenRocket.png",
+        description: "configuration for parsing the response",
+        example: {
+            example1: {
+                parseConfig: {
+                    icon: "greenRocket",
+                    iconUrl: ".../greenRocket.png",
+                },
             },
-            description: "Configuration for icon-based radio buttons",
+            example2: {
+                parseConfig: {
+                    yes: "Yes",
+                    no: "No",
+                },
+            },
         },
         required: false,
     })

--- a/src/forms/forms.response.ts
+++ b/src/forms/forms.response.ts
@@ -30,13 +30,11 @@ class OptionChoice {
     @Optional()
     @ApiProperty({
         examples: {
-            iconConfig: {
-                value: {
-                    icon: "greenRocket",
-                    iconUrl: ".../greenRocket.png",
-                },
-                description: "Configuration for icon-based radio buttons",
+            parseConfig: {
+                icon: "greenRocket",
+                iconUrl: ".../greenRocket.png",
             },
+            description: "Configuration for icon-based radio buttons",
         },
         required: false,
     })
@@ -120,13 +118,11 @@ class BaseQuestion {
     @Optional()
     @ApiProperty({
         examples: {
-            scaleConfig: {
-                value: {
-                    min: "Not Likely",
-                    max: "Extremely Likely",
-                },
-                description: "Configuration for scale questions",
+            parseConfig: {
+                min: "Not Likely",
+                max: "Extremely Likely",
             },
+            description: "Configuration for scale questions",
         },
         required: false,
     })

--- a/src/forms/forms.service.ts
+++ b/src/forms/forms.service.ts
@@ -31,12 +31,14 @@ export const formSelect = {
             description: true,
             answerRequired: true,
             multipleAllowed: true,
+            parseConfig: true,
             optionGroup: {
                 select: {
                     optionChoices: {
                         select: {
                             id: true,
                             text: true,
+                            parseConfig: true,
                         },
                     },
                 },
@@ -55,12 +57,14 @@ export const formSelect = {
                     description: true,
                     answerRequired: true,
                     multipleAllowed: true,
+                    parseConfig: true,
                     optionGroup: {
                         select: {
                             optionChoices: {
                                 select: {
                                     id: true,
                                     text: true,
+                                    parseConfig: true,
                                 },
                             },
                         },

--- a/src/global/dtos/FormResponse.dto.ts
+++ b/src/global/dtos/FormResponse.dto.ts
@@ -48,17 +48,9 @@ export class FormResponseDto {
         description: "configuration for parsing the response",
         required: false,
         example: {
-            example1: {
-                parseConfig: {
-                    icon: "greenRocket",
-                    iconUrl: ".../greenRocket.png",
-                },
-            },
-            example2: {
-                parseConfig: {
-                    yes: "Yes",
-                    no: "No",
-                },
+            parseConfig: {
+                icon: "greenRocket",
+                iconUrl: ".../greenRocket.png",
             },
         },
     })

--- a/src/global/dtos/FormResponse.dto.ts
+++ b/src/global/dtos/FormResponse.dto.ts
@@ -46,23 +46,21 @@ export class FormResponseDto {
 
     @ApiProperty({
         description: "configuration for parsing the response",
-        examples: {
-            iconConfig: {
-                value: {
+        required: false,
+        example: {
+            example1: {
+                parseConfig: {
                     icon: "greenRocket",
                     iconUrl: ".../greenRocket.png",
                 },
-                description: "Configuration for icon-based radio buttons",
             },
-            booleanConfig: {
-                value: {
+            example2: {
+                parseConfig: {
                     yes: "Yes",
                     no: "No",
                 },
-                description: "Configuration for boolean questions",
             },
         },
-        required: false,
     })
     @IsOptional()
     @IsObject()

--- a/src/global/dtos/FormResponse.dto.ts
+++ b/src/global/dtos/FormResponse.dto.ts
@@ -1,11 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import {
-    IsBoolean,
-    IsNumber,
-    IsOptional,
-    IsString,
-    IsObject,
-} from "class-validator";
+import { IsBoolean, IsNumber, IsOptional, IsString } from "class-validator";
 
 export class FormResponseDto {
     @ApiProperty({
@@ -43,18 +37,4 @@ export class FormResponseDto {
     @IsNumber()
     @IsOptional()
     numeric?: number;
-
-    @ApiProperty({
-        description: "configuration for parsing the response",
-        required: false,
-        example: {
-            parseConfig: {
-                icon: "greenRocket",
-                iconUrl: ".../greenRocket.png",
-            },
-        },
-    })
-    @IsOptional()
-    @IsObject()
-    parseConfig?: Record<string, any>;
 }

--- a/src/global/dtos/FormResponse.dto.ts
+++ b/src/global/dtos/FormResponse.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsBoolean, IsNumber, IsOptional, IsString } from "class-validator";
+import {
+    IsBoolean,
+    IsNumber,
+    IsOptional,
+    IsString,
+    IsObject,
+} from "class-validator";
 
 export class FormResponseDto {
     @ApiProperty({
@@ -37,4 +43,28 @@ export class FormResponseDto {
     @IsNumber()
     @IsOptional()
     numeric?: number;
+
+    @ApiProperty({
+        description: "configuration for parsing the response",
+        examples: {
+            iconConfig: {
+                value: {
+                    icon: "greenRocket",
+                    iconUrl: ".../greenRocket.png",
+                },
+                description: "Configuration for icon-based radio buttons",
+            },
+            booleanConfig: {
+                value: {
+                    yes: "Yes",
+                    no: "No",
+                },
+                description: "Configuration for boolean questions",
+            },
+        },
+        required: false,
+    })
+    @IsOptional()
+    @IsObject()
+    parseConfig?: Record<string, any>;
 }

--- a/src/global/mocks/mock-data.ts
+++ b/src/global/mocks/mock-data.ts
@@ -287,6 +287,7 @@ export const createMockData = {
                 },
                 text: "Question 1",
                 description: "Description 1",
+                parseConfig: null,
                 answerRequired: true,
                 multipleAllowed: null,
                 optionGroup: {

--- a/src/sprints/sprints.controller.spec.ts
+++ b/src/sprints/sprints.controller.spec.ts
@@ -37,6 +37,7 @@ describe("SprintsController", () => {
         meetingId: 1,
         formId: 1,
         responseGroupId: 1,
+        parseConfig: {},
         createdAt: mockDate,
         updatedAt: mockDate,
     };

--- a/src/sprints/sprints.response.ts
+++ b/src/sprints/sprints.response.ts
@@ -205,6 +205,15 @@ export class MeetingFormResponse {
 
     @ApiProperty({ example: 5 })
     responseGroupId: number;
+
+    @ApiProperty({
+        example: {
+            min: "Not Likely",
+            max: "Extremely Likely",
+        },
+    })
+    @Optional()
+    parseConfig?: Record<string, any>;
 }
 
 export class CheckinSubmissionResponse {

--- a/src/sprints/sprints.service.spec.ts
+++ b/src/sprints/sprints.service.spec.ts
@@ -1362,11 +1362,13 @@ describe("SprintsService", () => {
                                         optionChoices: {
                                             select: {
                                                 id: true,
+                                                parseConfig: true,
                                                 text: true,
                                             },
                                         },
                                     },
                                 },
+                                parseConfig: true,
                                 responses: {
                                     where: {
                                         responseGroupId:

--- a/src/sprints/sprints.service.ts
+++ b/src/sprints/sprints.service.ts
@@ -489,12 +489,14 @@ export class SprintsService {
                         description: true,
                         answerRequired: true,
                         multipleAllowed: true,
+                        parseConfig: true,
                         optionGroup: {
                             select: {
                                 optionChoices: {
                                     select: {
                                         id: true,
                                         text: true,
+                                        parseConfig: true,
                                     },
                                 },
                             },


### PR DESCRIPTION
# Description

Added support for adding the `parseConfig` field to fetching of form questions configuration, along with flexibility. This new optional field allows for additional configuration parameters to be stored for different question types, such as:
- Icon-based radio buttons
- Scale questions with custom min/max labels
- Boolean questions with custom yes/no text

In addition, A new wiki page was created called [Form Input types v2](https://github.com/chingu-x/chingu-dashboard-be/wiki/Form-Input-types-v2)

The changes include:
1. Added `parseConfig` field to `OptionChoice` and `BaseQuestion` classes
2. Updated form selection queries to include the new field
3. Added proper validation and Swagger documentation

## Issue link

Fixes # [86b3u7ygj](https://app.clickup.com/t/86b3u7ygj)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature updates / changes
- [ ] Tests
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

The changes have been tested through:
1. API endpoint testing to verify parseConfig is properly saved and retrieved
2. Validation of parseConfig object structure
3. Swagger documentation generation
4. Existing functionality remains unchanged

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the change log