### PR TITLE
chore: update node version in lint workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "18"
+          node-version: "22"
 
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
update node version to 22 in lint and test workflow

# Description

Fix #249 failing test and lint workflow due to node version being too low
![image](https://github.com/user-attachments/assets/2b5a9059-cf7f-43c6-be4f-7ddd34db1c8a)


# How Has This Been Tested?

Tested on my fork - https://github.com/cherylli/chingu-dashboard-be/actions/runs/14008118704/job/39224526712?pr=11 


